### PR TITLE
Docs: Japanese app spec in README and add data-structures.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,36 @@
-# brewia
+# Brewia
 
-This is a [Next.js](https://nextjs.org) project bootstrapped with [v0](https://v0.app).
+世界各国のコーヒー豆との出会いと、その豆をどのように抽出し、どのように味わったかを、飛行機のフライトログのように記録するモバイルアプリ。単なる記録ではなく、豆ごとの履歴と、抽出ごとの体験が積み重なっていく「コーヒー体験の航海日誌」のようなプロダクトです。
 
-## Built with v0
+## Specification
 
-This repository is linked to a [v0](https://v0.app) project. You can continue developing by visiting the link below -- start new chats to make changes, and v0 will push commits directly to this repo. Every merge to `main` will automatically deploy.
+### Core Features
+- 豆（Bean）情報の登録・閲覧
+- 抽出（Brew）ログの作成・閲覧
+- 風味（Flavor）タグ付け
+- 抽出ステップ（時間と注湯量）の記録
+- テイスティングスコア（aroma / acidity / sweetness / body / overall）の記録
 
-[Continue working on v0 →](https://v0.app/chat/projects/prj_P79JqauUkq3v6kacbO4W41e1omn5)
+### Primary Screens
+- トップ: 豆・抽出のサマリー表示
+- 新規作成: 豆登録 / 抽出登録
+- 豆詳細: 豆の基本情報 + 紐づく抽出履歴
+- 抽出詳細: レシピ、ステップ、評価、フレーバー
+
+### Non-functional Requirements
+- モバイル利用を前提にした操作性
+- 数値入力のしやすさ（グラム、秒、温度）
+- 将来の永続化層差し替えを考慮した型中心設計
+
+## Data Structures
+
+- [data-structures.md](./docs/data-structures.md)
 
 ## Getting Started
 
-First, run the development server:
-
 ```bash
-npm run dev
-# or
-yarn dev
-# or
+pnpm install
 pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-## Learn More
-
-To learn more, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-- [v0 Documentation](https://v0.app/docs) - learn about v0 and how to use it.
-
-<a href="https://v0.app/chat/api/kiro/clone/yjn279/brewia" alt="Open in Kiro"><img src="https://pdgvvgmkdvyeydso.public.blob.vercel-storage.com/open%20in%20kiro.svg?sanitize=true" /></a>
+ブラウザで `http://localhost:3000` を開いて確認してください。

--- a/docs/data-structures.md
+++ b/docs/data-structures.md
@@ -1,0 +1,147 @@
+# Data Structures
+
+`lib/types.ts` の型情報を、名称・変数名・型・概要で整理しています。
+
+## Bean
+
+| 名称 | 変数名 | 型 | 概要 |
+| --- | --- | --- | --- |
+| 豆ID | id | string | 豆を一意に識別するID |
+| 豆名 | name | string | コーヒー豆の名称 |
+| 生産国 | country | string | 豆の生産国 |
+| 生産地域 | region | string | 豆の生産地域 |
+| 農園名 | farm | string | 生産農園 |
+| 精製方法 | process | string | ウォッシュト/ナチュラルなど |
+| 品種 | variety | string | コーヒー豆の品種 |
+| 焙煎度 | roast | number | 1-5の焙煎レベル |
+| ロースター | roaster | string | 焙煎した店舗/ブランド名 |
+| メモ | notes | string | 豆に関する自由記述 |
+| 作成日時 | created | string | レコード作成日時 |
+| 更新日時 | updated | string | レコード更新日時 |
+
+## Brew
+
+| 名称 | 変数名 | 型 | 概要 |
+| --- | --- | --- | --- |
+| 抽出ID | id | string | 抽出ログを一意に識別するID |
+| 豆ID | beanId | string | 紐づく Bean のID |
+| 豆量 | beanWeight | number | 使用した豆の重量（g） |
+| 挽き目 | beanGrind | number | 挽き目の指標値 |
+| 湯量 | waterWeight | number | 使用した総湯量（g/ml） |
+| 湯温 | waterTemp | number | 抽出時の湯温（℃） |
+| 注湯ステップ | steps | BrewStep[] | 時間と注湯量の配列データ |
+| 香り | aroma | number | 香りの評価（1-5） |
+| 酸味 | acidity | number | 酸味の評価（1-5） |
+| 甘さ | sweetness | number | 甘さの評価（1-5） |
+| ボディ | body | number | コク/質感の評価（1-5） |
+| 総合 | overall | number | 総合評価（1-5） |
+| メモ | notes | string | 抽出に関する自由記述 |
+| 作成日時 | created | string | レコード作成日時 |
+| 更新日時 | updated | string | レコード更新日時 |
+
+## BrewStep（JSON構造）
+
+```json
+[
+  { "time": 0, "water": 0 },
+  { "time": 30, "water": 40 },
+  { "time": 60, "water": 120 },
+  { "time": 90, "water": 180 },
+  { "time": 120, "water": 225 }
+]
+```
+
+| 名称 | 変数名 | 型 | 概要 |
+| --- | --- | --- | --- |
+| 経過時間 | time | number | 抽出開始からの経過秒数 |
+| 累計注湯量 | water | number | その時点までの累計注湯量 |
+
+## Flavor
+
+| 名称 | 変数名 | 型 | 概要 |
+| --- | --- | --- | --- |
+| フレーバーID | id | string | フレーバーを一意に識別するID |
+| フレーバー名 | name | string | 風味名（例: Citrus） |
+| カテゴリ | category | string | 大分類 |
+| サブカテゴリ | subcategory | string | 小分類 |
+| 作成日時 | created | string | レコード作成日時 |
+| 更新日時 | updated | string | レコード更新日時 |
+
+## BrewFlavor
+
+| 名称 | 変数名 | 型 | 概要 |
+| --- | --- | --- | --- |
+| 紐づけID | id | string | Brew と Flavor の関連ID |
+| 抽出ID | brewId | string | 紐づく Brew のID |
+| フレーバーID | flavorId | string | 紐づく Flavor のID |
+| 作成日時 | created | string | レコード作成日時 |
+| 更新日時 | updated | string | レコード更新日時 |
+
+## Joined Types
+
+| 名称 | 変数名 | 型 | 概要 |
+| --- | --- | --- | --- |
+| BeanWithBrews | BeanWithBrews | `extends Bean` | Bean に紐づく抽出一覧を含む型 |
+| 抽出一覧 | brews | `Brew[]` | BeanWithBrews で追加されるプロパティ |
+| BrewWithBean | BrewWithBean | `extends Brew` | 抽出ログに豆情報と風味一覧を含む型 |
+| 豆情報 | bean | `Bean` | BrewWithBean で追加されるプロパティ |
+| 風味一覧 | flavors | `Flavor[]` | BrewWithBean で追加されるプロパティ |
+
+## Data
+
+```mermaid
+erDiagram
+    BEAN ||--o{ BREW : has
+    BREW ||--o{ BREW_FLAVOR : tagged_with
+    FLAVOR ||--o{ BREW_FLAVOR : assigned_to
+
+    BEAN {
+        string id PK
+        string name
+        string country
+        string region
+        string farm
+        string process
+        string variety
+        int roast
+        string roaster
+        text notes
+        datetime created
+        datetime updated
+    }
+
+    BREW {
+        string id PK
+        string bean_id FK
+        decimal bean_weight
+        decimal bean_grind
+        decimal water_weight
+        decimal water_temp
+        text steps
+        int aroma
+        int acidity
+        int sweetness
+        int body
+        int overall
+        text notes
+        datetime created
+        datetime updated
+    }
+
+    FLAVOR {
+        string id PK
+        string name
+        string category
+        string subcategory
+        datetime created
+        datetime updated
+    }
+
+    BREW_FLAVOR {
+        string id PK
+        string brew_id FK
+        string flavor_id FK
+        datetime created
+        datetime updated
+    }
+```


### PR DESCRIPTION
### Motivation
- Replace the generic Next.js boilerplate README with a project-specific specification describing the mobile-first coffee log product (Brewia). 
- Provide a clear developer `Getting Started` instruction that matches the project's preferred package manager. 
- Introduce a dedicated reference for domain types so frontend and future backend work share a single canonical spec.

### Description
- Overhauled `README.md` to include a Japanese specification of the app, core features, primary screens, non-functional requirements, and updated `Getting Started` steps using `pnpm install` and `pnpm dev`.
- Removed the previous v0 integration blurb and example links in favor of project-focused documentation and a pointer to the new data structure doc. 
- Added `docs/data-structures.md` containing detailed type tables for `Bean`, `Brew`, `BrewStep`, `Flavor`, `BrewFlavor`, joined types, and an ER diagram to document relationships and JSON examples.

### Testing
- No automated tests were executed for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5c840a8288322b7b5cad8aee2f782)