### PR TITLE
Refresh frontend with modern yellow visual redesign

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,80 +4,80 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  /* Warm coffee palette - cream, espresso, caramel */
-  --background: oklch(0.97 0.01 75);
-  --foreground: oklch(0.25 0.03 50);
-  --card: oklch(0.99 0.005 75);
-  --card-foreground: oklch(0.25 0.03 50);
-  --popover: oklch(0.99 0.005 75);
-  --popover-foreground: oklch(0.25 0.03 50);
-  --primary: oklch(0.35 0.08 55);
-  --primary-foreground: oklch(0.98 0.01 75);
-  --secondary: oklch(0.92 0.02 75);
-  --secondary-foreground: oklch(0.35 0.06 55);
-  --muted: oklch(0.94 0.015 75);
-  --muted-foreground: oklch(0.50 0.03 55);
-  --accent: oklch(0.65 0.12 55);
-  --accent-foreground: oklch(0.98 0.01 75);
-  --destructive: oklch(0.55 0.22 27);
-  --destructive-foreground: oklch(0.55 0.22 27);
-  --border: oklch(0.88 0.02 75);
-  --input: oklch(0.92 0.015 75);
-  --ring: oklch(0.55 0.10 55);
-  --chart-1: oklch(0.52 0.08 52);
-  --chart-2: oklch(0.60 0.07 62);
-  --chart-3: oklch(0.45 0.07 40);
-  --chart-4: oklch(0.68 0.08 72);
-  --chart-5: oklch(0.56 0.07 30);
-  --radius: 0.75rem;
-  --sidebar: oklch(0.98 0.01 75);
-  --sidebar-foreground: oklch(0.25 0.03 50);
-  --sidebar-primary: oklch(0.35 0.08 55);
-  --sidebar-primary-foreground: oklch(0.98 0.01 75);
-  --sidebar-accent: oklch(0.94 0.02 75);
-  --sidebar-accent-foreground: oklch(0.35 0.06 55);
-  --sidebar-border: oklch(0.88 0.02 75);
-  --sidebar-ring: oklch(0.55 0.10 55);
+  --background: oklch(0.985 0.02 95);
+  --foreground: oklch(0.27 0.03 68);
+  --card: oklch(0.99 0.012 95);
+  --card-foreground: oklch(0.27 0.03 68);
+  --popover: oklch(0.99 0.012 95);
+  --popover-foreground: oklch(0.27 0.03 68);
+  --primary: oklch(0.79 0.16 88);
+  --primary-foreground: oklch(0.22 0.03 68);
+  --secondary: oklch(0.95 0.04 95);
+  --secondary-foreground: oklch(0.3 0.04 72);
+  --muted: oklch(0.95 0.024 93);
+  --muted-foreground: oklch(0.48 0.04 74);
+  --accent: oklch(0.73 0.17 84);
+  --accent-foreground: oklch(0.18 0.03 65);
+  --destructive: oklch(0.58 0.2 25);
+  --destructive-foreground: oklch(0.97 0.01 85);
+  --border: oklch(0.9 0.03 90);
+  --input: oklch(0.95 0.02 94);
+  --ring: oklch(0.75 0.16 88);
+  --chart-1: oklch(0.77 0.15 86);
+  --chart-2: oklch(0.68 0.12 80);
+  --chart-3: oklch(0.59 0.09 74);
+  --chart-4: oklch(0.85 0.1 92);
+  --chart-5: oklch(0.5 0.07 68);
+  --radius: 1rem;
+  --sidebar: oklch(0.98 0.015 96);
+  --sidebar-foreground: oklch(0.27 0.03 68);
+  --sidebar-primary: oklch(0.79 0.16 88);
+  --sidebar-primary-foreground: oklch(0.2 0.03 65);
+  --sidebar-accent: oklch(0.95 0.03 94);
+  --sidebar-accent-foreground: oklch(0.3 0.04 72);
+  --sidebar-border: oklch(0.9 0.03 90);
+  --sidebar-ring: oklch(0.75 0.16 88);
 }
 
 .dark {
-  --background: oklch(0.18 0.02 55);
-  --foreground: oklch(0.94 0.01 75);
-  --card: oklch(0.22 0.025 55);
-  --card-foreground: oklch(0.94 0.01 75);
-  --popover: oklch(0.22 0.025 55);
-  --popover-foreground: oklch(0.94 0.01 75);
-  --primary: oklch(0.75 0.10 70);
-  --primary-foreground: oklch(0.18 0.02 55);
-  --secondary: oklch(0.28 0.03 55);
-  --secondary-foreground: oklch(0.94 0.01 75);
-  --muted: oklch(0.28 0.025 55);
-  --muted-foreground: oklch(0.65 0.03 70);
-  --accent: oklch(0.65 0.12 55);
-  --accent-foreground: oklch(0.18 0.02 55);
-  --destructive: oklch(0.45 0.18 25);
-  --destructive-foreground: oklch(0.65 0.22 25);
-  --border: oklch(0.32 0.025 55);
-  --input: oklch(0.28 0.025 55);
-  --ring: oklch(0.55 0.10 55);
-  --chart-1: oklch(0.66 0.08 55);
-  --chart-2: oklch(0.72 0.07 65);
-  --chart-3: oklch(0.58 0.06 42);
-  --chart-4: oklch(0.76 0.08 74);
-  --chart-5: oklch(0.67 0.07 34);
-  --sidebar: oklch(0.20 0.025 55);
-  --sidebar-foreground: oklch(0.94 0.01 75);
-  --sidebar-primary: oklch(0.75 0.10 70);
-  --sidebar-primary-foreground: oklch(0.18 0.02 55);
-  --sidebar-accent: oklch(0.28 0.03 55);
-  --sidebar-accent-foreground: oklch(0.94 0.01 75);
-  --sidebar-border: oklch(0.32 0.025 55);
-  --sidebar-ring: oklch(0.55 0.10 55);
+  --background: oklch(0.2 0.03 60);
+  --foreground: oklch(0.95 0.02 95);
+  --card: oklch(0.23 0.03 60);
+  --card-foreground: oklch(0.95 0.02 95);
+  --popover: oklch(0.23 0.03 60);
+  --popover-foreground: oklch(0.95 0.02 95);
+  --primary: oklch(0.8 0.16 88);
+  --primary-foreground: oklch(0.22 0.03 64);
+  --secondary: oklch(0.29 0.03 60);
+  --secondary-foreground: oklch(0.95 0.02 95);
+  --muted: oklch(0.28 0.03 60);
+  --muted-foreground: oklch(0.76 0.04 88);
+  --accent: oklch(0.74 0.16 84);
+  --accent-foreground: oklch(0.19 0.03 62);
+  --destructive: oklch(0.56 0.2 25);
+  --destructive-foreground: oklch(0.96 0.02 95);
+  --border: oklch(0.35 0.03 60);
+  --input: oklch(0.3 0.03 60);
+  --ring: oklch(0.8 0.16 88);
+  --chart-1: oklch(0.77 0.14 86);
+  --chart-2: oklch(0.7 0.12 80);
+  --chart-3: oklch(0.61 0.09 75);
+  --chart-4: oklch(0.84 0.09 92);
+  --chart-5: oklch(0.53 0.08 68);
+  --sidebar: oklch(0.23 0.03 60);
+  --sidebar-foreground: oklch(0.95 0.02 95);
+  --sidebar-primary: oklch(0.8 0.16 88);
+  --sidebar-primary-foreground: oklch(0.22 0.03 64);
+  --sidebar-accent: oklch(0.29 0.03 60);
+  --sidebar-accent-foreground: oklch(0.95 0.02 95);
+  --sidebar-border: oklch(0.35 0.03 60);
+  --sidebar-ring: oklch(0.8 0.16 88);
 }
 
 @theme inline {
-  --font-sans: 'Geist', 'Geist Fallback';
-  --font-mono: 'Geist Mono', 'Geist Mono Fallback';
+  --font-sans: var(--font-sans);
+  --font-display: var(--font-display);
+  --font-mono: var(--font-mono);
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);
@@ -120,7 +120,13 @@
   * {
     @apply border-border outline-ring/50;
   }
+
   body {
     @apply bg-background text-foreground;
+    background-image:
+      radial-gradient(circle at 15% 10%, oklch(0.92 0.08 95 / 0.95), transparent 48%),
+      radial-gradient(circle at 85% 0%, oklch(0.87 0.12 88 / 0.8), transparent 52%),
+      linear-gradient(160deg, oklch(0.99 0.01 96) 0%, oklch(0.95 0.04 93) 100%);
+    background-attachment: fixed;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,20 @@
 import type { Metadata, Viewport } from 'next'
-import { DM_Sans, DM_Mono } from 'next/font/google'
+import { Manrope, Cormorant_Garamond, DM_Mono } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/next'
 import './globals.css'
 
-const dmSans = DM_Sans({ 
+const manrope = Manrope({
   subsets: ['latin'],
   variable: '--font-sans',
 })
 
-const dmMono = DM_Mono({ 
+const cormorant = Cormorant_Garamond({
+  subsets: ['latin'],
+  variable: '--font-display',
+  weight: ['500', '600', '700'],
+})
+
+const dmMono = DM_Mono({
   subsets: ['latin'],
   weight: ['400', '500'],
   variable: '--font-mono',
@@ -24,7 +30,7 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
-  themeColor: '#4a3728',
+  themeColor: '#f6c62c',
 }
 
 export default function RootLayout({
@@ -34,7 +40,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${dmSans.variable} ${dmMono.variable} font-sans antialiased`}>
+      <body className={`${manrope.variable} ${cormorant.variable} ${dmMono.variable} font-sans antialiased`}>
         {children}
         <Analytics />
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,7 +21,6 @@ export default async function HomePage() {
     getBrews(),
   ])
 
-  // Calculate stats
   const totalBrews = brews.length
   const totalBeans = beans.length
   const uniqueCountries = new Set(beans.map((b) => b.country)).size
@@ -30,75 +29,53 @@ export default async function HomePage() {
     : '0.0'
 
   return (
-    <div className="min-h-screen bg-background">
-      {/* Header */}
-      <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur-sm">
-        <div className="mx-auto flex h-14 max-w-md items-center justify-between px-4">
-          <div className="flex items-center">
-            <span className="text-xl font-semibold tracking-tight text-foreground">Brewia</span>
+    <div className="min-h-screen pb-10">
+      <header className="sticky top-0 z-40 border-b border-black/5 bg-background/75 backdrop-blur-xl">
+        <div className="mx-auto flex h-16 max-w-3xl items-center justify-between px-4 sm:px-6">
+          <div className="flex items-end gap-2">
+            <span className="font-display text-3xl font-semibold leading-none tracking-tight text-foreground">Brewia</span>
+            <span className="mb-1 rounded-full bg-primary/25 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-foreground/80">Journal</span>
           </div>
-          <div className="flex items-center gap-2">
-            <Link
-              href="/new?type=bean"
-              className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground hover:bg-primary/90"
-            >
-              <Plus className="h-4 w-4" />
-            </Link>
-          </div>
+          <Link
+            href="/new?type=bean"
+            className="group flex h-10 w-10 items-center justify-center rounded-full border border-black/10 bg-primary text-primary-foreground shadow-[0_8px_20px_-12px_rgba(0,0,0,0.6)] transition-all hover:-translate-y-0.5 hover:shadow-[0_10px_26px_-12px_rgba(0,0,0,0.6)]"
+          >
+            <Plus className="h-4 w-4 transition-transform group-hover:rotate-90" />
+          </Link>
         </div>
       </header>
 
-      <main className="mx-auto max-w-md px-4 py-6">
-        {/* Welcome */}
-        <section className="mb-6">
+      <main className="mx-auto mt-6 max-w-3xl px-4 sm:px-6">
+        <section className="mb-7 rounded-3xl border border-black/5 bg-card/80 p-6 shadow-[0_28px_60px_-45px_rgba(80,60,20,0.6)] backdrop-blur">
           <Greeting />
-          <p className="mt-1 text-muted-foreground">
-            Your coffee journey continues
+          <p className="mt-2 text-sm text-muted-foreground">
+            Your coffee journey continues with clarity and better notes.
           </p>
         </section>
 
-        {/* Stats Grid */}
-        <section className="mb-8 grid grid-cols-2 gap-3">
-          <StatsCard
-            label="Total Brews"
-            value={totalBrews}
-            icon={<Flame className="h-3.5 w-3.5" />}
-          />
-          <StatsCard
-            label="Bean Varieties"
-            value={totalBeans}
-            icon={<Coffee className="h-3.5 w-3.5" />}
-          />
-          <StatsCard
-            label="Countries"
-            value={uniqueCountries}
-            icon={<Globe className="h-3.5 w-3.5" />}
-          />
-          <StatsCard
-            label="Avg Rating"
-            value={avgRating}
-            icon={<Star className="h-3.5 w-3.5" />}
-          />
+        <section className="mb-9 grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <StatsCard label="Total Brews" value={totalBrews} icon={<Flame className="h-3.5 w-3.5" />} />
+          <StatsCard label="Bean Varieties" value={totalBeans} icon={<Coffee className="h-3.5 w-3.5" />} />
+          <StatsCard label="Countries" value={uniqueCountries} icon={<Globe className="h-3.5 w-3.5" />} />
+          <StatsCard label="Avg Rating" value={avgRating} icon={<Star className="h-3.5 w-3.5" />} />
         </section>
 
-        {/* Bean Library */}
-        <section className="mb-6">
-          <h2 className="mb-4 text-sm font-medium uppercase tracking-wider text-muted-foreground">
-            Bean Library
-          </h2>
+        <section>
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">Bean Library</h2>
+            <span className="rounded-full border border-black/10 bg-background/70 px-3 py-1 text-[11px] font-medium text-muted-foreground">
+              {beans.length} items
+            </span>
+          </div>
+
           {beans.length > 0 ? (
-            <div className="flex flex-col gap-3">
+            <div className="grid gap-3 sm:grid-cols-2">
               {beans.map((bean) => {
-                return (
-                  <BeanCard
-                    key={bean.id}
-                    bean={bean}
-                  />
-                )
+                return <BeanCard key={bean.id} bean={bean} />
               })}
             </div>
           ) : (
-            <Empty className="rounded-xl border border-dashed bg-card px-4 py-10 shadow-sm">
+            <Empty className="rounded-3xl border border-dashed border-black/10 bg-card/70 px-4 py-10 shadow-sm">
               <EmptyHeader>
                 <EmptyMedia variant="icon">
                   <Coffee className="h-5 w-5" />
@@ -111,7 +88,7 @@ export default async function HomePage() {
               <EmptyContent>
                 <Link
                   href="/new?type=bean"
-                  className="inline-flex h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+                  className="inline-flex h-10 items-center justify-center rounded-full bg-primary px-4 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/85"
                 >
                   Add your first bean
                 </Link>

--- a/components/bean-card.tsx
+++ b/components/bean-card.tsx
@@ -10,33 +10,29 @@ interface BeanCardProps {
 
 export function BeanCard({ bean, className }: BeanCardProps) {
   const flag = COUNTRY_FLAGS[bean.country]
-  
+
   return (
     <Link
       href={`/beans/${bean.id}`}
       className={cn(
-        'block rounded-xl bg-card p-4 shadow-sm transition-all hover:shadow-md active:scale-[0.98]',
-        className
+        'group block rounded-2xl border border-black/5 bg-card/80 p-4 shadow-[0_18px_36px_-30px_rgba(38,28,8,0.9)] backdrop-blur-sm transition-all hover:-translate-y-0.5 hover:border-black/15',
+        className,
       )}
     >
       <div className="flex items-start gap-3">
-        <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-secondary text-2xl">
+        <div className="flex h-12 w-12 items-center justify-center rounded-xl border border-black/5 bg-secondary text-2xl transition-transform group-hover:scale-105">
           {flag}
         </div>
         <div className="min-w-0 flex-1">
-          <h3 className="truncate font-medium text-foreground">{bean.name}</h3>
+          <h3 className="truncate text-base font-semibold text-foreground">{bean.name}</h3>
           <p className="text-sm text-muted-foreground">
             {bean.region}, {bean.country}
           </p>
-          <div className="mt-2 flex items-center gap-3 text-xs text-muted-foreground">
-            <span className="flex items-center gap-1">
-              <span>{bean.variety}</span>
-            </span>
-            <span className="text-border">|</span>
-            <span className="flex items-center gap-1">
-              <span>{bean.process}</span>
-            </span>
-            <span className="text-border">|</span>
+          <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+            <span>{bean.variety}</span>
+            <span className="text-border">•</span>
+            <span>{bean.process}</span>
+            <span className="text-border">•</span>
             <span>{bean.roast}</span>
           </div>
         </div>

--- a/components/greeting.tsx
+++ b/components/greeting.tsx
@@ -17,7 +17,7 @@ export function Greeting() {
   }, [])
 
   return (
-    <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+    <h1 className="font-display text-4xl font-semibold leading-none tracking-tight text-foreground sm:text-5xl">
       {greeting}
     </h1>
   )
@@ -32,13 +32,9 @@ export function CurrentDate() {
         weekday: 'short',
         month: 'short',
         day: 'numeric',
-      })
+      }),
     )
   }, [])
 
-  return (
-    <time className="font-mono text-xs text-muted-foreground">
-      {dateStr}
-    </time>
-  )
+  return <time className="font-mono text-xs text-muted-foreground">{dateStr}</time>
 }

--- a/components/stats-card.tsx
+++ b/components/stats-card.tsx
@@ -9,13 +9,15 @@ interface StatsCardProps {
 
 export function StatsCard({ label, value, icon, className }: StatsCardProps) {
   return (
-    <div className={cn(
-      'flex flex-col gap-1 rounded-xl bg-card p-4 shadow-sm',
-      className
-    )}>
-      <div className="flex items-center gap-2 text-muted-foreground">
-        {icon}
-        <span className="text-xs uppercase tracking-wider">{label}</span>
+    <div
+      className={cn(
+        'rounded-2xl border border-black/5 bg-card/85 p-4 shadow-[0_16px_30px_-25px_rgba(38,28,8,0.7)] backdrop-blur-sm transition-transform hover:-translate-y-0.5',
+        className,
+      )}
+    >
+      <div className="mb-2 flex items-center gap-2 text-muted-foreground">
+        <span className="rounded-full bg-primary/25 p-1.5 text-foreground">{icon}</span>
+        <span className="text-[11px] font-semibold uppercase tracking-[0.14em]">{label}</span>
       </div>
       <span className="font-mono text-2xl font-medium text-foreground">{value}</span>
     </div>


### PR DESCRIPTION
### Motivation

- Refresh the app's visual language to a modern, refined, yellow‑led aesthetic with improved hierarchy and breathing space.
- Make the home/dashboard feel more polished and memorable through refined typography, layered backgrounds, and subtle motion-friendly classes.
- Improve readability and visual consistency across stats, bean cards, and the welcome area while keeping the UI simple and approachable.

### Description

- Updated global design tokens and background treatment in `app/globals.css` to a brighter yellow/cream palette, increased corner radii, and layered radial/linear gradients to add depth.
- Replaced font choices and exposed font variables in `app/layout.tsx` using `Manrope`, `Cormorant_Garamond`, and `DM_Mono`, and adjusted the `themeColor` to match the new palette.
- Reworked top-level layout and home composition in `app/page.tsx` to use a wider max container, rounded cards, a refined header, and a denser grid layout for stats and bean listings.
- Restyled UI components: `components/stats-card.tsx` (new card visual, icon chip and hover lift), `components/bean-card.tsx` (rounded card, flag frame, tighter metadata chips), and `components/greeting.tsx` (display font, larger scale). The changes are committed.

### Testing

- Ran `pnpm install` successfully to restore and add runtime deps. ✅
- Ran type checks with `pnpm exec tsc --noEmit` and there were no TypeScript errors. ✅
- Ran `pnpm lint` but it failed due to the environment lacking an ESLint flat `eslint.config.*` (ESLint v9 migration) so linting was not validated. ⚠️
- Attempted `pnpm build` but the Next/Turbopack production build failed in this environment because Google Fonts fetching/module resolution and Turbopack font processing could not complete, causing the build to fail. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca7fd39e288322aa7519a7fd45e9c9)