### PR TITLE
Refactor data layer into service/repository layers and add PUT/DELETE APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@
 
 - [data-structures.md](./docs/data-structures.md)
 
+## Architecture
+
+- [clean-architecture.md](./docs/clean-architecture.md)
+
 ## Getting Started
 
 ```bash

--- a/app/api/beans/[id]/route.ts
+++ b/app/api/beans/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
-import { getBeanById } from '@/lib/db'
+import { beansService } from '@/lib/server/beans/beans.service'
+import { upsertBeanSchema } from '@/lib/server/beans/beans.schema'
 
 export const dynamic = 'force-dynamic'
 
@@ -9,11 +10,40 @@ interface BeanRouteProps {
 
 export async function GET(_: Request, { params }: BeanRouteProps) {
   const { id } = await params
-  const bean = await getBeanById(id)
+  const bean = await beansService.getBeanById(id)
 
   if (!bean) {
     return NextResponse.json({ error: 'Bean not found' }, { status: 404 })
   }
 
   return NextResponse.json(bean)
+}
+
+export async function PUT(request: Request, { params }: BeanRouteProps) {
+  const { id } = await params
+  const json = await request.json()
+  const parsed = upsertBeanSchema.safeParse(json)
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+
+  const bean = await beansService.updateBean(id, parsed.data)
+
+  if (!bean) {
+    return NextResponse.json({ error: 'Bean not found' }, { status: 404 })
+  }
+
+  return NextResponse.json(bean)
+}
+
+export async function DELETE(_: Request, { params }: BeanRouteProps) {
+  const { id } = await params
+  const deleted = await beansService.deleteBean(id)
+
+  if (!deleted) {
+    return NextResponse.json({ error: 'Bean not found' }, { status: 404 })
+  }
+
+  return new Response(null, { status: 204 })
 }

--- a/app/api/beans/route.ts
+++ b/app/api/beans/route.ts
@@ -1,54 +1,23 @@
 import { NextResponse } from 'next/server'
-import { z } from 'zod'
-import { COUNTRIES, ROAST_LEVELS } from '@/lib/types'
-import { createBean, getBeans } from '@/lib/db'
+import { beansService } from '@/lib/server/beans/beans.service'
+import { upsertBeanSchema } from '@/lib/server/beans/beans.schema'
 
 export const dynamic = 'force-dynamic'
 
-const createBeanSchema = z.object({
-  name: z.string().trim().min(1),
-  roaster: z.string().trim().min(1),
-  country: z.enum(COUNTRIES),
-  region: z.string().trim().optional(),
-  farm: z.string().trim().optional(),
-  variety: z.string().trim().optional(),
-  process: z.string().trim().optional(),
-  roast: z.enum(ROAST_LEVELS),
-  notes: z.string().trim().optional(),
-})
-
-function toNullable(value?: string): string | null {
-  if (!value) {
-    return null
-  }
-
-  return value.length > 0 ? value : null
-}
-
 export async function POST(request: Request) {
   const json = await request.json()
-  const parsed = createBeanSchema.safeParse(json)
+  const parsed = upsertBeanSchema.safeParse(json)
 
   if (!parsed.success) {
     return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
   }
 
-  const bean = await createBean({
-    name: parsed.data.name,
-    roaster: parsed.data.roaster,
-    country: parsed.data.country,
-    region: toNullable(parsed.data.region),
-    farm: toNullable(parsed.data.farm),
-    variety: toNullable(parsed.data.variety),
-    process: toNullable(parsed.data.process),
-    roast: parsed.data.roast,
-    notes: toNullable(parsed.data.notes),
-  })
+  const bean = await beansService.createBean(parsed.data)
 
   return NextResponse.json({ id: bean.id }, { status: 201 })
 }
 
 export async function GET() {
-  const beans = await getBeans()
+  const beans = await beansService.getBeans()
   return NextResponse.json(beans)
 }

--- a/app/api/brews/[id]/route.ts
+++ b/app/api/brews/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
-import { getBrewById } from '@/lib/db'
+import { brewsService } from '@/lib/server/brews/brews.service'
+import { upsertBrewSchema } from '@/lib/server/brews/brews.schema'
 
 export const dynamic = 'force-dynamic'
 
@@ -9,11 +10,40 @@ interface BrewRouteProps {
 
 export async function GET(_: Request, { params }: BrewRouteProps) {
   const { id } = await params
-  const brew = await getBrewById(id)
+  const brew = await brewsService.getBrewById(id)
 
   if (!brew) {
     return NextResponse.json({ error: 'Brew not found' }, { status: 404 })
   }
 
   return NextResponse.json(brew)
+}
+
+export async function PUT(request: Request, { params }: BrewRouteProps) {
+  const { id } = await params
+  const json = await request.json()
+  const parsed = upsertBrewSchema.safeParse(json)
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+
+  const brew = await brewsService.updateBrew(id, parsed.data)
+
+  if (!brew) {
+    return NextResponse.json({ error: 'Brew not found' }, { status: 404 })
+  }
+
+  return NextResponse.json(brew)
+}
+
+export async function DELETE(_: Request, { params }: BrewRouteProps) {
+  const { id } = await params
+  const deleted = await brewsService.deleteBrew(id)
+
+  if (!deleted) {
+    return NextResponse.json({ error: 'Brew not found' }, { status: 404 })
+  }
+
+  return new Response(null, { status: 204 })
 }

--- a/app/api/brews/route.ts
+++ b/app/api/brews/route.ts
@@ -1,55 +1,18 @@
 import { NextResponse } from 'next/server'
-import { z } from 'zod'
-import { createBrew, getBrews, getBrewsByBeanId } from '@/lib/db'
+import { brewsService } from '@/lib/server/brews/brews.service'
+import { upsertBrewSchema } from '@/lib/server/brews/brews.schema'
 
 export const dynamic = 'force-dynamic'
 
-const createBrewSchema = z.object({
-  beanId: z.string().trim().min(1),
-  beanWeight: z.coerce.number().positive(),
-  beanGrind: z.coerce.number().positive().nullable(),
-  waterWeight: z.coerce.number().positive(),
-  waterTemp: z.coerce.number().min(0).max(100).nullable(),
-  aroma: z.coerce.number().int().min(1).max(5),
-  acidity: z.coerce.number().int().min(1).max(5),
-  sweetness: z.coerce.number().int().min(1).max(5),
-  body: z.coerce.number().int().min(1).max(5),
-  overall: z.coerce.number().int().min(1).max(5),
-  notes: z.string().trim().optional(),
-  flavorIds: z.array(z.string().trim().min(1)).default([]),
-})
-
-function toNullable(value?: string): string | null {
-  if (!value) {
-    return null
-  }
-
-  return value.length > 0 ? value : null
-}
-
 export async function POST(request: Request) {
   const json = await request.json()
-  const parsed = createBrewSchema.safeParse(json)
+  const parsed = upsertBrewSchema.safeParse(json)
 
   if (!parsed.success) {
     return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
   }
 
-  const brew = await createBrew({
-    beanId: parsed.data.beanId,
-    beanWeight: parsed.data.beanWeight,
-    beanGrind: parsed.data.beanGrind,
-    waterWeight: parsed.data.waterWeight,
-    waterTemp: parsed.data.waterTemp,
-    steps: [],
-    aroma: parsed.data.aroma,
-    acidity: parsed.data.acidity,
-    sweetness: parsed.data.sweetness,
-    body: parsed.data.body,
-    overall: parsed.data.overall,
-    notes: toNullable(parsed.data.notes),
-    flavorIds: [...new Set(parsed.data.flavorIds)],
-  })
+  const brew = await brewsService.createBrew(parsed.data)
 
   return NextResponse.json({ id: brew.id }, { status: 201 })
 }
@@ -59,10 +22,10 @@ export async function GET(request: Request) {
   const beanId = searchParams.get('beanId')
 
   if (beanId) {
-    const brews = await getBrewsByBeanId(beanId)
+    const brews = await brewsService.getBrewsByBeanId(beanId)
     return NextResponse.json(brews)
   }
 
-  const brews = await getBrews()
+  const brews = await brewsService.getBrews()
   return NextResponse.json(brews)
 }

--- a/app/api/flavors/route.ts
+++ b/app/api/flavors/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server'
-import { getFlavors } from '@/lib/db'
+import { flavorsService } from '@/lib/server/flavors/flavors.service'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET() {
-  const flavors = await getFlavors()
+  const flavors = await flavorsService.getFlavors()
   return NextResponse.json(flavors)
 }

--- a/docs/clean-architecture.md
+++ b/docs/clean-architecture.md
@@ -1,0 +1,82 @@
+# Clean Architecture / API リファクタリング概要
+
+本ドキュメントは、`lib/server` 配下に導入したレイヤー構成と、追加された編集・削除 API の仕様をまとめたものです。
+
+## 1. 目的
+
+- Nest.js で一般的なファイル命名（`*.service.ts`）に寄せて責務を明確化する。
+- ルーティング層と永続化層を分離し、保守性を高める。
+- Bean/Brew の CRUD を API レベルで揃える（編集・削除の追加）。
+
+## 2. レイヤー構成
+
+```text
+app/api/*                # Controller 相当（HTTP 入出力）
+  └─ route.ts
+
+lib/server/*             # アプリケーション層 / インフラ層
+  ├─ *.schema.ts         # DTO バリデーション（Zod）
+  ├─ *.service.ts        # ユースケース
+  └─ *.repository.ts     # DB アクセス（Drizzle）
+
+lib/db/index.ts          # 既存コード互換の Facade
+```
+
+### 各層の責務
+
+- **route.ts**
+  - リクエスト受け取り
+  - スキーマ検証
+  - HTTP ステータスを含むレスポンス生成
+- **service**
+  - 入力正規化
+  - ユースケース実行（作成/更新/削除/参照）
+  - 必要な repository 呼び出しのオーケストレーション
+- **repository**
+  - Drizzle を使った SQL 実行
+  - トランザクション管理
+  - DB row と型のマッピング
+
+## 3. 追加 API（編集 / 削除）
+
+### Beans
+
+- `PUT /api/beans/:id`
+  - Bean を更新
+  - バリデーション失敗: `400`
+  - 対象なし: `404`
+  - 成功: `200`（更新後オブジェクト）
+
+- `DELETE /api/beans/:id`
+  - Bean を削除
+  - 関連 Brew と BrewFlavor もトランザクション内で削除
+  - 対象なし: `404`
+  - 成功: `204`
+
+### Brews
+
+- `PUT /api/brews/:id`
+  - Brew を更新
+  - 更新時に BrewFlavor を一旦削除して再登録
+  - バリデーション失敗: `400`
+  - 対象なし: `404`
+  - 成功: `200`（更新後オブジェクト）
+
+- `DELETE /api/brews/:id`
+  - Brew を削除
+  - 関連 BrewFlavor も削除
+  - 対象なし: `404`
+  - 成功: `204`
+
+## 4. DTO / バリデーション
+
+- `lib/server/beans/beans.schema.ts`
+  - Bean の作成・更新 payload を共通定義
+- `lib/server/brews/brews.schema.ts`
+  - Brew の作成・更新 payload を共通定義
+
+## 5. 互換性ポリシー
+
+- 既存ページや処理が `@/lib/db` を参照しているため、
+  `lib/db/index.ts` は service を委譲する **Facade** として維持。
+- これにより呼び出し側の大きな改修なしで内部構造のみ段階的に改善。

--- a/docs/data-structures.md
+++ b/docs/data-structures.md
@@ -9,13 +9,13 @@
 | 豆ID | id | string | 豆を一意に識別するID |
 | 豆名 | name | string | コーヒー豆の名称 |
 | 生産国 | country | string | 豆の生産国 |
-| 生産地域 | region | string | 豆の生産地域 |
-| 農園名 | farm | string | 生産農園 |
-| 精製方法 | process | string | ウォッシュト/ナチュラルなど |
-| 品種 | variety | string | コーヒー豆の品種 |
-| 焙煎度 | roast | number | 1-5の焙煎レベル |
-| ロースター | roaster | string | 焙煎した店舗/ブランド名 |
-| メモ | notes | string | 豆に関する自由記述 |
+| 生産地域 | region | string \| null | 豆の生産地域（未入力可） |
+| 農園名 | farm | string \| null | 生産農園（未入力可） |
+| 精製方法 | process | string \| null | ウォッシュト/ナチュラルなど（未入力可） |
+| 品種 | variety | string \| null | コーヒー豆の品種（未入力可） |
+| 焙煎度 | roast | RoastLevel (string) | 焙煎度（Light / Cinnamon / Medium / High / City / Full City / French / Italian） |
+| ロースター | roaster | string \| null | 焙煎した店舗/ブランド名（未入力可） |
+| メモ | notes | string \| null | 豆に関する自由記述（未入力可） |
 | 作成日時 | created | string | レコード作成日時 |
 | 更新日時 | updated | string | レコード更新日時 |
 
@@ -26,16 +26,16 @@
 | 抽出ID | id | string | 抽出ログを一意に識別するID |
 | 豆ID | beanId | string | 紐づく Bean のID |
 | 豆量 | beanWeight | number | 使用した豆の重量（g） |
-| 挽き目 | beanGrind | number | 挽き目の指標値 |
+| 挽き目 | beanGrind | number \| null | 挽き目の指標値（未入力可） |
 | 湯量 | waterWeight | number | 使用した総湯量（g/ml） |
-| 湯温 | waterTemp | number | 抽出時の湯温（℃） |
+| 湯温 | waterTemp | number \| null | 抽出時の湯温（℃、未入力可） |
 | 注湯ステップ | steps | BrewStep[] | 時間と注湯量の配列データ |
 | 香り | aroma | number | 香りの評価（1-5） |
 | 酸味 | acidity | number | 酸味の評価（1-5） |
 | 甘さ | sweetness | number | 甘さの評価（1-5） |
 | ボディ | body | number | コク/質感の評価（1-5） |
 | 総合 | overall | number | 総合評価（1-5） |
-| メモ | notes | string | 抽出に関する自由記述 |
+| メモ | notes | string \| null | 抽出に関する自由記述（未入力可） |
 | 作成日時 | created | string | レコード作成日時 |
 | 更新日時 | updated | string | レコード更新日時 |
 
@@ -103,7 +103,7 @@ erDiagram
         string farm
         string process
         string variety
-        int roast
+        string roast
         string roaster
         text notes
         datetime created

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -1,3 +1,23 @@
-export { getBeans, getBeanById, createBean } from '@/lib/db/beans'
-export { getBrews, getBrewsByBeanId, getBrewById, getBrewCountByBeanIdMap, createBrew } from '@/lib/db/brews'
-export { getFlavors, getFlavorsByBrewId, getFlavorMapByBeanId } from '@/lib/db/flavors'
+import { beansService } from '@/lib/server/beans/beans.service'
+import { brewsService } from '@/lib/server/brews/brews.service'
+import { flavorsService } from '@/lib/server/flavors/flavors.service'
+
+export { beansService, brewsService, flavorsService }
+
+export const getBeans = () => beansService.getBeans()
+export const getBeanById = (id: string) => beansService.getBeanById(id)
+export const createBean = (input: Parameters<typeof beansService.createBean>[0]) => beansService.createBean(input)
+export const updateBean = (id: string, input: Parameters<typeof beansService.updateBean>[1]) => beansService.updateBean(id, input)
+export const deleteBean = (id: string) => beansService.deleteBean(id)
+
+export const getBrews = () => brewsService.getBrews()
+export const getBrewsByBeanId = (beanId: string) => brewsService.getBrewsByBeanId(beanId)
+export const getBrewById = (id: string) => brewsService.getBrewById(id)
+export const getBrewCountByBeanIdMap = () => brewsService.getBrewCountByBeanIdMap()
+export const createBrew = (input: Parameters<typeof brewsService.createBrew>[0]) => brewsService.createBrew(input)
+export const updateBrew = (id: string, input: Parameters<typeof brewsService.updateBrew>[1]) => brewsService.updateBrew(id, input)
+export const deleteBrew = (id: string) => brewsService.deleteBrew(id)
+
+export const getFlavors = () => flavorsService.getFlavors()
+export const getFlavorsByBrewId = (brewId: string) => flavorsService.getFlavorsByBrewId(brewId)
+export const getFlavorMapByBeanId = (beanId: string) => flavorsService.getFlavorMapByBeanId(beanId)

--- a/lib/server/beans/beans.repository.ts
+++ b/lib/server/beans/beans.repository.ts
@@ -1,0 +1,103 @@
+import 'server-only'
+
+import { desc, eq } from 'drizzle-orm'
+import type { Bean } from '@/lib/types'
+import { db } from '@/lib/db/drizzle'
+import { beansTable, brewFlavorsTable, brewsTable } from '@/lib/db/schema'
+
+export interface BeanMutationInput {
+  name: string
+  country: Bean['country']
+  roast: Bean['roast']
+  roaster: string | null
+  region: string | null
+  farm: string | null
+  process: string | null
+  variety: string | null
+  notes: string | null
+}
+
+function mapBeanRow(row: typeof beansTable.$inferSelect): Bean {
+  return {
+    ...row,
+    country: row.country as Bean['country'],
+    roast: row.roast as Bean['roast'],
+  }
+}
+
+export class BeansRepository {
+  async findAll(): Promise<Bean[]> {
+    const rows = await db
+      .select()
+      .from(beansTable)
+      .orderBy(desc(beansTable.updated))
+
+    return rows.map(mapBeanRow)
+  }
+
+  async findById(id: string): Promise<Bean | undefined> {
+    const [row] = await db
+      .select()
+      .from(beansTable)
+      .where(eq(beansTable.id, id))
+      .limit(1)
+
+    return row ? mapBeanRow(row) : undefined
+  }
+
+  async create(input: BeanMutationInput): Promise<Bean> {
+    const [row] = await db
+      .insert(beansTable)
+      .values(input)
+      .returning()
+
+    return mapBeanRow(row)
+  }
+
+  async update(id: string, input: BeanMutationInput): Promise<Bean | undefined> {
+    const [row] = await db
+      .update(beansTable)
+      .set({
+        ...input,
+        updated: new Date().toISOString(),
+      })
+      .where(eq(beansTable.id, id))
+      .returning()
+
+    return row ? mapBeanRow(row) : undefined
+  }
+
+  async delete(id: string): Promise<boolean> {
+    const deleted = await db.transaction(async (tx) => {
+      const brewRows = await tx
+        .select({ id: brewsTable.id })
+        .from(brewsTable)
+        .where(eq(brewsTable.beanId, id))
+
+      if (brewRows.length > 0) {
+        const brewIds = brewRows.map((row) => row.id)
+
+        for (const brewId of brewIds) {
+          await tx
+            .delete(brewFlavorsTable)
+            .where(eq(brewFlavorsTable.brewId, brewId))
+        }
+
+        for (const brewId of brewIds) {
+          await tx
+            .delete(brewsTable)
+            .where(eq(brewsTable.id, brewId))
+        }
+      }
+
+      const result = await tx
+        .delete(beansTable)
+        .where(eq(beansTable.id, id))
+        .returning({ id: beansTable.id })
+
+      return result.length > 0
+    })
+
+    return deleted
+  }
+}

--- a/lib/server/beans/beans.schema.ts
+++ b/lib/server/beans/beans.schema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+import { COUNTRIES, ROAST_LEVELS } from '@/lib/types'
+
+export const upsertBeanSchema = z.object({
+  name: z.string().trim().min(1),
+  roaster: z.string().trim().min(1),
+  country: z.enum(COUNTRIES),
+  region: z.string().trim().optional(),
+  farm: z.string().trim().optional(),
+  variety: z.string().trim().optional(),
+  process: z.string().trim().optional(),
+  roast: z.enum(ROAST_LEVELS),
+  notes: z.string().trim().optional(),
+})
+
+export type UpsertBeanDto = z.infer<typeof upsertBeanSchema>

--- a/lib/server/beans/beans.service.ts
+++ b/lib/server/beans/beans.service.ts
@@ -1,0 +1,51 @@
+import 'server-only'
+
+import { toNullableString } from '@/lib/server/common/null-string.util'
+import { BeansRepository } from '@/lib/server/beans/beans.repository'
+import type { UpsertBeanDto } from '@/lib/server/beans/beans.schema'
+
+const beansRepository = new BeansRepository()
+
+export class BeansService {
+  async getBeans() {
+    return beansRepository.findAll()
+  }
+
+  async getBeanById(id: string) {
+    return beansRepository.findById(id)
+  }
+
+  async createBean(dto: UpsertBeanDto) {
+    return beansRepository.create({
+      name: dto.name,
+      roaster: dto.roaster,
+      country: dto.country,
+      region: toNullableString(dto.region),
+      farm: toNullableString(dto.farm),
+      variety: toNullableString(dto.variety),
+      process: toNullableString(dto.process),
+      roast: dto.roast,
+      notes: toNullableString(dto.notes),
+    })
+  }
+
+  async updateBean(id: string, dto: UpsertBeanDto) {
+    return beansRepository.update(id, {
+      name: dto.name,
+      roaster: dto.roaster,
+      country: dto.country,
+      region: toNullableString(dto.region),
+      farm: toNullableString(dto.farm),
+      variety: toNullableString(dto.variety),
+      process: toNullableString(dto.process),
+      roast: dto.roast,
+      notes: toNullableString(dto.notes),
+    })
+  }
+
+  async deleteBean(id: string) {
+    return beansRepository.delete(id)
+  }
+}
+
+export const beansService = new BeansService()

--- a/lib/server/brews/brews.repository.ts
+++ b/lib/server/brews/brews.repository.ts
@@ -1,0 +1,199 @@
+import 'server-only'
+
+import { count, desc, eq } from 'drizzle-orm'
+import type { Brew, BrewStep, BrewWithBean } from '@/lib/types'
+import { db } from '@/lib/db/drizzle'
+import { brewFlavorsTable, brewsTable } from '@/lib/db/schema'
+import { parseSteps } from '@/lib/db/row-utils'
+import { BeansRepository } from '@/lib/server/beans/beans.repository'
+import { FlavorsRepository } from '@/lib/server/flavors/flavors.repository'
+
+export interface BrewMutationInput {
+  beanId: string
+  beanWeight: number
+  beanGrind: number | null
+  waterWeight: number
+  waterTemp: number | null
+  steps: BrewStep[]
+  aroma: number
+  acidity: number
+  sweetness: number
+  body: number
+  overall: number
+  notes: string | null
+  flavorIds: string[]
+}
+
+function mapBrewRow(row: typeof brewsTable.$inferSelect): Brew {
+  return {
+    ...row,
+    steps: parseSteps(row.steps),
+  }
+}
+
+const beansRepository = new BeansRepository()
+const flavorsRepository = new FlavorsRepository()
+
+export class BrewsRepository {
+  async findAll(): Promise<Brew[]> {
+    const rows = await db
+      .select()
+      .from(brewsTable)
+      .orderBy(desc(brewsTable.created))
+
+    return rows.map(mapBrewRow)
+  }
+
+  async findCountByBeanIdMap(): Promise<Map<string, number>> {
+    const rows = await db
+      .select({ beanId: brewsTable.beanId, brewCount: count(brewsTable.id) })
+      .from(brewsTable)
+      .groupBy(brewsTable.beanId)
+
+    return new Map(rows.map((row) => [row.beanId, row.brewCount]))
+  }
+
+  async findByBeanId(beanId: string): Promise<BrewWithBean[]> {
+    const [bean, brewRows, flavorByBrewId] = await Promise.all([
+      beansRepository.findById(beanId),
+      db
+        .select()
+        .from(brewsTable)
+        .where(eq(brewsTable.beanId, beanId))
+        .orderBy(desc(brewsTable.created)),
+      flavorsRepository.findMapByBeanId(beanId),
+    ])
+
+    if (!bean) {
+      return []
+    }
+
+    return brewRows.map((row) => {
+      const brew = mapBrewRow(row)
+      return {
+        ...brew,
+        bean,
+        flavors: flavorByBrewId.get(brew.id) ?? [],
+      }
+    })
+  }
+
+  async findById(id: string): Promise<BrewWithBean | undefined> {
+    const [brewRow] = await db
+      .select()
+      .from(brewsTable)
+      .where(eq(brewsTable.id, id))
+      .limit(1)
+
+    if (!brewRow) {
+      return undefined
+    }
+
+    const brew = mapBrewRow(brewRow)
+    const [bean, flavors] = await Promise.all([
+      beansRepository.findById(brew.beanId),
+      flavorsRepository.findByBrewId(id),
+    ])
+
+    if (!bean) {
+      return undefined
+    }
+
+    return {
+      ...brew,
+      bean,
+      flavors,
+    }
+  }
+
+  async create(input: BrewMutationInput): Promise<Brew> {
+    return db.transaction(async (tx) => {
+      const [brewRow] = await tx
+        .insert(brewsTable)
+        .values({
+          beanId: input.beanId,
+          beanWeight: input.beanWeight,
+          beanGrind: input.beanGrind,
+          waterWeight: input.waterWeight,
+          waterTemp: input.waterTemp,
+          steps: JSON.stringify(input.steps),
+          aroma: input.aroma,
+          acidity: input.acidity,
+          sweetness: input.sweetness,
+          body: input.body,
+          overall: input.overall,
+          notes: input.notes,
+        })
+        .returning()
+
+      if (input.flavorIds.length > 0) {
+        await tx.insert(brewFlavorsTable).values(
+          input.flavorIds.map((flavorId) => ({
+            brewId: brewRow.id,
+            flavorId,
+          }))
+        )
+      }
+
+      return mapBrewRow(brewRow)
+    })
+  }
+
+  async update(id: string, input: BrewMutationInput): Promise<Brew | undefined> {
+    return db.transaction(async (tx) => {
+      const [brewRow] = await tx
+        .update(brewsTable)
+        .set({
+          beanId: input.beanId,
+          beanWeight: input.beanWeight,
+          beanGrind: input.beanGrind,
+          waterWeight: input.waterWeight,
+          waterTemp: input.waterTemp,
+          steps: JSON.stringify(input.steps),
+          aroma: input.aroma,
+          acidity: input.acidity,
+          sweetness: input.sweetness,
+          body: input.body,
+          overall: input.overall,
+          notes: input.notes,
+          updated: new Date().toISOString(),
+        })
+        .where(eq(brewsTable.id, id))
+        .returning()
+
+      if (!brewRow) {
+        return undefined
+      }
+
+      await tx
+        .delete(brewFlavorsTable)
+        .where(eq(brewFlavorsTable.brewId, id))
+
+      if (input.flavorIds.length > 0) {
+        await tx.insert(brewFlavorsTable).values(
+          input.flavorIds.map((flavorId) => ({
+            brewId: id,
+            flavorId,
+          }))
+        )
+      }
+
+      return mapBrewRow(brewRow)
+    })
+  }
+
+  async delete(id: string): Promise<boolean> {
+    return db.transaction(async (tx) => {
+      await tx
+        .delete(brewFlavorsTable)
+        .where(eq(brewFlavorsTable.brewId, id))
+
+      const result = await tx
+        .delete(brewsTable)
+        .where(eq(brewsTable.id, id))
+        .returning({ id: brewsTable.id })
+
+      return result.length > 0
+    })
+  }
+}

--- a/lib/server/brews/brews.schema.ts
+++ b/lib/server/brews/brews.schema.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod'
+
+export const upsertBrewSchema = z.object({
+  beanId: z.string().trim().min(1),
+  beanWeight: z.coerce.number().positive(),
+  beanGrind: z.coerce.number().positive().nullable(),
+  waterWeight: z.coerce.number().positive(),
+  waterTemp: z.coerce.number().min(0).max(100).nullable(),
+  aroma: z.coerce.number().int().min(1).max(5),
+  acidity: z.coerce.number().int().min(1).max(5),
+  sweetness: z.coerce.number().int().min(1).max(5),
+  body: z.coerce.number().int().min(1).max(5),
+  overall: z.coerce.number().int().min(1).max(5),
+  notes: z.string().trim().optional(),
+  flavorIds: z.array(z.string().trim().min(1)).default([]),
+})
+
+export type UpsertBrewDto = z.infer<typeof upsertBrewSchema>

--- a/lib/server/brews/brews.service.ts
+++ b/lib/server/brews/brews.service.ts
@@ -1,0 +1,67 @@
+import 'server-only'
+
+import { toNullableString } from '@/lib/server/common/null-string.util'
+import { BrewsRepository } from '@/lib/server/brews/brews.repository'
+import type { UpsertBrewDto } from '@/lib/server/brews/brews.schema'
+
+const brewsRepository = new BrewsRepository()
+
+export class BrewsService {
+  async getBrews() {
+    return brewsRepository.findAll()
+  }
+
+  async getBrewCountByBeanIdMap() {
+    return brewsRepository.findCountByBeanIdMap()
+  }
+
+  async getBrewsByBeanId(beanId: string) {
+    return brewsRepository.findByBeanId(beanId)
+  }
+
+  async getBrewById(id: string) {
+    return brewsRepository.findById(id)
+  }
+
+  async createBrew(dto: UpsertBrewDto) {
+    return brewsRepository.create({
+      beanId: dto.beanId,
+      beanWeight: dto.beanWeight,
+      beanGrind: dto.beanGrind,
+      waterWeight: dto.waterWeight,
+      waterTemp: dto.waterTemp,
+      steps: [],
+      aroma: dto.aroma,
+      acidity: dto.acidity,
+      sweetness: dto.sweetness,
+      body: dto.body,
+      overall: dto.overall,
+      notes: toNullableString(dto.notes),
+      flavorIds: [...new Set(dto.flavorIds)],
+    })
+  }
+
+  async updateBrew(id: string, dto: UpsertBrewDto) {
+    return brewsRepository.update(id, {
+      beanId: dto.beanId,
+      beanWeight: dto.beanWeight,
+      beanGrind: dto.beanGrind,
+      waterWeight: dto.waterWeight,
+      waterTemp: dto.waterTemp,
+      steps: [],
+      aroma: dto.aroma,
+      acidity: dto.acidity,
+      sweetness: dto.sweetness,
+      body: dto.body,
+      overall: dto.overall,
+      notes: toNullableString(dto.notes),
+      flavorIds: [...new Set(dto.flavorIds)],
+    })
+  }
+
+  async deleteBrew(id: string) {
+    return brewsRepository.delete(id)
+  }
+}
+
+export const brewsService = new BrewsService()

--- a/lib/server/common/null-string.util.ts
+++ b/lib/server/common/null-string.util.ts
@@ -1,0 +1,7 @@
+export function toNullableString(value?: string): string | null {
+  if (!value) {
+    return null
+  }
+
+  return value.length > 0 ? value : null
+}

--- a/lib/server/flavors/flavors.repository.ts
+++ b/lib/server/flavors/flavors.repository.ts
@@ -1,0 +1,85 @@
+import 'server-only'
+
+import { asc, eq } from 'drizzle-orm'
+import { db } from '@/lib/db/drizzle'
+import { brewFlavorsTable, brewsTable, flavorsTable } from '@/lib/db/schema'
+import type { Flavor } from '@/lib/types'
+
+function isMissingFlavorTableError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+
+  const message = error.message.toLowerCase()
+  return message.includes('no such table') && message.includes('flavor')
+}
+
+function mapFlavorRow(row: typeof flavorsTable.$inferSelect): Flavor {
+  return row
+}
+
+export class FlavorsRepository {
+  async findAll(): Promise<Flavor[]> {
+    try {
+      const rows = await db
+        .select()
+        .from(flavorsTable)
+        .orderBy(asc(flavorsTable.name))
+
+      return rows.map(mapFlavorRow)
+    } catch (error) {
+      if (isMissingFlavorTableError(error)) {
+        return []
+      }
+
+      throw error
+    }
+  }
+
+  async findByBrewId(brewId: string): Promise<Flavor[]> {
+    try {
+      const rows = await db
+        .select({ flavor: flavorsTable })
+        .from(brewFlavorsTable)
+        .innerJoin(flavorsTable, eq(flavorsTable.id, brewFlavorsTable.flavorId))
+        .where(eq(brewFlavorsTable.brewId, brewId))
+        .orderBy(asc(flavorsTable.name))
+
+      return rows.map((row) => mapFlavorRow(row.flavor))
+    } catch (error) {
+      if (isMissingFlavorTableError(error)) {
+        return []
+      }
+
+      throw error
+    }
+  }
+
+  async findMapByBeanId(beanId: string): Promise<Map<string, Flavor[]>> {
+    let rows: Array<{ brewId: string; flavor: typeof flavorsTable.$inferSelect }> = []
+
+    try {
+      rows = await db
+        .select({ brewId: brewFlavorsTable.brewId, flavor: flavorsTable })
+        .from(brewFlavorsTable)
+        .innerJoin(flavorsTable, eq(flavorsTable.id, brewFlavorsTable.flavorId))
+        .innerJoin(brewsTable, eq(brewsTable.id, brewFlavorsTable.brewId))
+        .where(eq(brewsTable.beanId, beanId))
+        .orderBy(asc(flavorsTable.name))
+    } catch (error) {
+      if (!isMissingFlavorTableError(error)) {
+        throw error
+      }
+    }
+
+    const flavorsByBrewId = new Map<string, Flavor[]>()
+
+    for (const row of rows) {
+      const list = flavorsByBrewId.get(row.brewId) ?? []
+      list.push(mapFlavorRow(row.flavor))
+      flavorsByBrewId.set(row.brewId, list)
+    }
+
+    return flavorsByBrewId
+  }
+}

--- a/lib/server/flavors/flavors.service.ts
+++ b/lib/server/flavors/flavors.service.ts
@@ -1,0 +1,21 @@
+import 'server-only'
+
+import { FlavorsRepository } from '@/lib/server/flavors/flavors.repository'
+
+const flavorsRepository = new FlavorsRepository()
+
+export class FlavorsService {
+  async getFlavors() {
+    return flavorsRepository.findAll()
+  }
+
+  async getFlavorsByBrewId(brewId: string) {
+    return flavorsRepository.findByBrewId(brewId)
+  }
+
+  async getFlavorMapByBeanId(beanId: string) {
+    return flavorsRepository.findMapByBeanId(beanId)
+  }
+}
+
+export const flavorsService = new FlavorsService()


### PR DESCRIPTION
### Motivation
- 整理された責務分離のため、DBアクセス・ユースケース・バリデーションをそれぞれのレイヤーに分離してクリーンアーキテクチャ寄りに移行する目的です。 
- Nest.js風の命名規則（`*.service.ts`, `*.repository.ts`, `*.schema.ts`）に合わせて実装をわかりやすくします。 
- APIの編集（PUT）と削除（DELETE）機能が不足していたため、それらを追加して CRUD を完全化します。

### Description
- 新たに `lib/server` 下へレイヤーを追加し、`beans`, `brews`, `flavors` ごとに `*.repository.ts`（DBアクセス）、`*.service.ts`（ユースケース）、`*.schema.ts`（Zod DTO）を実装しました。 
- 既存の API ルートを直接 DB 呼び出しからサービス呼び出しへ差し替えし、入力バリデーションは共通の Zod スキーマ（`lib/server/*/*.schema.ts`）で行うようにしました。 
- `PUT /api/beans/[id]`, `DELETE /api/beans/[id]`, `PUT /api/brews/[id]`, `DELETE /api/brews/[id]` のエンドポイントを追加し、存在しないリソースは `404`、削除成功は `204` を返す挙動を実装しました。 
- リレーションの整合性（`brew_flavor` 中間テーブルや Bean に紐づく Brew の一括削除等）は `repository` レイヤーのトランザクションで処理するように移しました。 
- 互換性のため `lib/db/index.ts` をサービス群へのファサードに更新し、既存の呼び出しシグネチャ（`getBeans`, `createBrew` 等）を維持しました。 
- 文字列正規化ユーティリティ `toNullableString` を `lib/server/common/null-string.util.ts` に追加しました。

### Testing
- `pnpm exec tsc --noEmit` は成功して型チェックは通りました。 
- `pnpm lint` はリポジトリに ESLint のフラット設定（`eslint.config.*`）がないため失敗しました（設定不足による環境依存の問題）。 
- `pnpm build` はこの実行環境での外部 Google Fonts/Turbopack 解決に失敗してビルドできませんでしたが、失敗原因はフォント取得・Turbopack 解決に起因する外部要因で、今回のリファクタリング本体とは無関係です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1d439a50c832289cddd104fcab1ed)