### PR TITLE
Compact home stats and remove "Bean Library" heading

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -53,7 +53,7 @@ export default async function HomePage() {
         {/* Stats Grid */}
         <section className="mb-8">
           <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-muted-foreground">
-            Quick Stats
+            Your Coffee Journey
           </h2>
           <div className="grid grid-cols-2 gap-3">
             <div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -45,27 +45,28 @@ export default async function HomePage() {
       </header>
 
       <main className="mx-auto max-w-md px-4 py-6">
-        {/* Welcome + Stats */}
-        <section className="mb-8 flex items-start justify-between gap-3">
-          <div className="min-w-0 pt-1">
-            <Greeting />
-            <p className="mt-1 text-muted-foreground">
-              Your coffee journey continues
-            </p>
-          </div>
+        {/* Welcome */}
+        <section className="mb-6">
+          <Greeting />
+          <p className="mt-1 text-muted-foreground">
+            Your coffee journey continues
+          </p>
+        </section>
 
-          <div className="flex w-full max-w-[180px] flex-col gap-2">
+        {/* Stats Grid */}
+        <section className="mb-8 grid grid-cols-2 gap-3">
+          <div>
             <StatsCard
               label="Total Brews"
               value={totalBrews}
-              icon={<Flame className="h-3 w-3" />}
-              className="gap-0.5 p-2.5 [&>span]:text-lg [&_span]:tracking-wide"
+              icon={<Flame className="h-3.5 w-3.5" />}
             />
+          </div>
+          <div>
             <StatsCard
               label="Bean Variety"
               value={totalBeans}
-              icon={<Coffee className="h-3 w-3" />}
-              className="gap-0.5 p-2.5 [&>span]:text-lg [&_span]:tracking-wide"
+              icon={<Coffee className="h-3.5 w-3.5" />}
             />
           </div>
         </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -48,31 +48,36 @@ export default async function HomePage() {
         {/* Welcome */}
         <section className="mb-6">
           <Greeting />
-          <p className="mt-1 text-muted-foreground">
-            Your coffee journey continues
-          </p>
         </section>
 
         {/* Stats Grid */}
-        <section className="mb-8 grid grid-cols-2 gap-3">
-          <div>
-            <StatsCard
-              label="Total Brews"
-              value={totalBrews}
-              icon={<Flame className="h-3.5 w-3.5" />}
-            />
-          </div>
-          <div>
-            <StatsCard
-              label="Bean Variety"
-              value={totalBeans}
-              icon={<Coffee className="h-3.5 w-3.5" />}
-            />
+        <section className="mb-8">
+          <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-muted-foreground">
+            Quick Stats
+          </h2>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <StatsCard
+                label="Total Brews"
+                value={totalBrews}
+                icon={<Flame className="h-3.5 w-3.5" />}
+              />
+            </div>
+            <div>
+              <StatsCard
+                label="Bean Variety"
+                value={totalBeans}
+                icon={<Coffee className="h-3.5 w-3.5" />}
+              />
+            </div>
           </div>
         </section>
 
-        {/* Beans */}
+        {/* Bean Library */}
         <section className="mb-6">
+          <h2 className="mb-4 text-sm font-medium uppercase tracking-wider text-muted-foreground">
+            Bean Library
+          </h2>
           {beans.length > 0 ? (
             <div className="flex flex-col gap-3">
               {beans.map((bean) => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,7 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from '@/components/ui/empty'
-import { Coffee, Flame, Globe, Star, Plus } from 'lucide-react'
+import { Coffee, Flame, Plus } from 'lucide-react'
 import Link from 'next/link'
 
 export const dynamic = 'force-dynamic'
@@ -25,11 +25,6 @@ export default async function HomePage() {
   // Calculate stats
   const totalBrews = brews.length
   const totalBeans = beans.length
-  const uniqueCountries = new Set(beans.map((b) => b.country)).size
-  const avgRating = totalBrews > 0
-    ? (brews.reduce((sum, b) => sum + b.overall, 0) / totalBrews).toFixed(1)
-    : '0.0'
-
   return (
     <div className="min-h-screen bg-background">
       {/* Header */}
@@ -50,43 +45,33 @@ export default async function HomePage() {
       </header>
 
       <main className="mx-auto max-w-md px-4 py-6">
-        {/* Welcome */}
-        <section className="mb-6">
-          <Greeting />
-          <p className="mt-1 text-muted-foreground">
-            Your coffee journey continues
-          </p>
+        {/* Welcome + Stats */}
+        <section className="mb-8 flex items-start justify-between gap-3">
+          <div className="min-w-0 pt-1">
+            <Greeting />
+            <p className="mt-1 text-muted-foreground">
+              Your coffee journey continues
+            </p>
+          </div>
+
+          <div className="flex w-full max-w-[180px] flex-col gap-2">
+            <StatsCard
+              label="Total Brews"
+              value={totalBrews}
+              icon={<Flame className="h-3 w-3" />}
+              className="gap-0.5 p-2.5 [&>span]:text-lg [&_span]:tracking-wide"
+            />
+            <StatsCard
+              label="Bean Variety"
+              value={totalBeans}
+              icon={<Coffee className="h-3 w-3" />}
+              className="gap-0.5 p-2.5 [&>span]:text-lg [&_span]:tracking-wide"
+            />
+          </div>
         </section>
 
-        {/* Stats Grid */}
-        <section className="mb-8 grid grid-cols-2 gap-3">
-          <StatsCard
-            label="Total Brews"
-            value={totalBrews}
-            icon={<Flame className="h-3.5 w-3.5" />}
-          />
-          <StatsCard
-            label="Bean Varieties"
-            value={totalBeans}
-            icon={<Coffee className="h-3.5 w-3.5" />}
-          />
-          <StatsCard
-            label="Countries"
-            value={uniqueCountries}
-            icon={<Globe className="h-3.5 w-3.5" />}
-          />
-          <StatsCard
-            label="Avg Rating"
-            value={avgRating}
-            icon={<Star className="h-3.5 w-3.5" />}
-          />
-        </section>
-
-        {/* Bean Library */}
+        {/* Beans */}
         <section className="mb-6">
-          <h2 className="mb-4 text-sm font-medium uppercase tracking-wider text-muted-foreground">
-            Bean Library
-          </h2>
           {beans.length > 0 ? (
             <div className="flex flex-col gap-3">
               {beans.map((bean) => {


### PR DESCRIPTION
### Motivation
- Simplify the home screen by removing the large Bean Library heading and decluttering the stats area for a more compact layout.
- Show only the most-relevant summary stats (`Total Brews` and `Bean Variety`) next to the greeting to improve information density.
- Remove now-unused derived stats and imports to keep the page logic minimal.

### Description
- Moved greeting and stats into a single right-aligned header row and stacked the two stats compactly to the right of the greeting (updated layout/CSS). (`app/page.tsx`)
- Reduced the stats grid to only `Total Brews` and `Bean Variety`, and removed `Countries` and `Avg Rating` calculations and their icons. (`app/page.tsx`)
- Deleted the `Bean Library` section title so the bean cards render directly under the header area. (`app/page.tsx`)
- Added small styling adjustments to the `StatsCard` usages (`className` tweaks) to make the compact cards visually consistent. (`app/page.tsx`)

### Testing
- Ran `pnpm lint`, which failed due to the repository missing an `eslint.config.*` file, so linting could not complete in this environment and is reported as a tooling issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d24c5550ac83228bc47b94ba18c1f8)