### PR TITLE
docs: update README with revised Japanese product description and setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,24 @@
 # Brewia
 
-世界各国のコーヒー豆との出会いと、その豆をどのように抽出し、どのように味わったかを、飛行機のフライトログのように記録するモバイルアプリ。単なる記録ではなく、豆ごとの履歴と、抽出ごとの体験が積み重なっていく「コーヒー体験の航海日誌」のようなプロダクトです。
-
-## Specification
+世界各国のコーヒー豆との出会いと、その豆をどのように抽出してどのように味わったかを、記録するアプリ。単なる記録ではなく、豆ごとの履歴と、抽出ごとの体験が積み重なっていく「コーヒー体験の航海日誌」のようなプロダクトです。
 
 ### Core Features
 
-- 豆（Bean）情報の登録・閲覧
-- 抽出（Brew）ログの作成・閲覧
-- 風味（Flavor）タグ付け
-- 抽出ステップ（時間と注湯量）の記録
-- テイスティングスコア（aroma / acidity / sweetness / body / overall）の記録
+- コーヒー豆の情報管理
+- コーヒーの抽出レシピや、抽出したカップのログ管理
+- 抽出したカップのテイスティングノート
 
-### Primary Screens
+## Getting Started
 
-- トップ: 豆・抽出のサマリー表示
-- 新規作成: 豆登録 / 抽出登録
-- 豆詳細: 豆の基本情報 + 紐づく抽出履歴
-- 抽出詳細: レシピ、ステップ、評価、フレーバー
+このリポジトリをクローンした後、以下のコードを実行してサーバーを起動することができます。ブラウザで `http://localhost:3000` を開き、アプリケーションへアクセスしましょう！
 
-### Non-functional Requirements
-
-- モバイル利用を前提にした操作性
-- 数値入力のしやすさ（グラム、秒、温度）
-- 将来の永続化層差し替えを考慮した型中心設計
+```shell
+cd brewia
+pnpm install
+pnpm start
+```
 
 ## Documentation
 
 - [Development Guide](./docs/development-guide.md)
 - [Data Structures](./docs/data-structures.md)
-
-## Getting Started
-
-```bash
-pnpm install
-pnpm dev
-```
-
-ブラウザで `http://localhost:3000` を開いて確認してください。


### PR DESCRIPTION
### Motivation

- Replace the previous, longer README specification with the supplied concise Japanese product description to better reflect the product framing.
- Simplify the Core Features to the three requested user-facing items and provide clear local startup steps for contributors.

### Description

- Replaced the top-level project description with the provided Japanese text and removed the earlier `Specification`, `Primary Screens`, and `Non-functional Requirements` sections.
- Rewrote the Core Features to three bullets: bean information management, brew recipe and cup log management, and tasting notes.
- Updated `Getting Started` to show `cd brewia`, `pnpm install`, and `pnpm start`, and kept Documentation links to `./docs/development-guide.md` and `./docs/data-structures.md`.

### Testing

- Verified the updated `README.md` content with `nl -ba README.md | sed -n '1,200p'`, which showed the new text.
- Performed repository checks with `git status --short` and `git diff -- README.md` to confirm that only `README.md` changed and the diff matches the requested edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db6e48ecd48322ba1b126e3c522ac4)