### PR TITLE
feat: add "record cup later" toggle for draft brews (#63)

### DIFF
--- a/app/brews/[id]/page.test.tsx
+++ b/app/brews/[id]/page.test.tsx
@@ -121,4 +121,69 @@ describe('BrewDetailPage', () => {
       totalWater: 103,
     })
   })
+
+  // C1: brew.overall === 0 — TasteRadar is hidden
+  it('C1: given a stored brew with overall === 0, when the detail page renders, then no element with data-testid="taste-radar" is present', async () => {
+    const draftBrew: BrewWithBean = {
+      ...brew,
+      aroma: 0,
+      acidity: 0,
+      sweetness: 0,
+      body: 0,
+      overall: 0,
+      flavors: [],
+    }
+    getBrewByIdMock.mockResolvedValue(draftBrew)
+
+    const page = await BrewDetailPage({
+      params: Promise.resolve({ id: 'brew-1' }),
+    })
+
+    render(page)
+
+    expect(screen.queryByTestId('taste-radar')).toBeNull()
+  })
+
+  // C2: brew.overall === 0 — overall rating shows "-" not "0"
+  it('C2: given a stored brew with overall === 0, when the page renders, then the overall area shows "-" followed by "/5"', async () => {
+    const draftBrew: BrewWithBean = {
+      ...brew,
+      aroma: 0,
+      acidity: 0,
+      sweetness: 0,
+      body: 0,
+      overall: 0,
+      flavors: [],
+    }
+    getBrewByIdMock.mockResolvedValue(draftBrew)
+
+    const page = await BrewDetailPage({
+      params: Promise.resolve({ id: 'brew-1' }),
+    })
+
+    render(page)
+
+    // Expect "-" to be present in the rating area, and "/5" to still appear
+    expect(screen.getByText('-')).toBeDefined()
+    expect(screen.getByText('/5')).toBeDefined()
+
+    // "0" should NOT appear as the overall rating value
+    // (text "0" could exist elsewhere so we check the combined pattern)
+    const overallRatingText = screen.queryByText('0/5')
+    expect(overallRatingText).toBeNull()
+  })
+
+  // C3: brew.overall === 4 (happy path) — TasteRadar is rendered and rating shows "4/5"
+  it('C3: given a stored brew with overall === 4, when the page renders, then TasteRadar is rendered once and overall shows "4" and "/5"', async () => {
+    // Default mock already returns the brew with overall: 4
+    const page = await BrewDetailPage({
+      params: Promise.resolve({ id: 'brew-1' }),
+    })
+
+    render(page)
+
+    expect(screen.getByTestId('taste-radar')).toBeDefined()
+    expect(screen.getByText('4')).toBeDefined()
+    expect(screen.getByText('/5')).toBeDefined()
+  })
 })

--- a/app/brews/[id]/page.tsx
+++ b/app/brews/[id]/page.tsx
@@ -76,7 +76,7 @@ export default async function BrewDetailPage({ params }: BrewDetailPageProps) {
             <p className="text-sm text-muted-foreground">{brew.bean.roaster}</p>
           </div>
           <div className="text-right">
-            <span className="font-mono text-2xl font-semibold text-primary">{brew.overall}</span>
+            <span className="font-mono text-2xl font-semibold text-primary">{brew.overall === 0 ? '-' : brew.overall}</span>
             <span className="text-sm text-muted-foreground">/5</span>
           </div>
         </Link>
@@ -139,18 +139,20 @@ export default async function BrewDetailPage({ params }: BrewDetailPageProps) {
         </section>
 
         {/* Taste Profile */}
-        <section className="mb-6 rounded-xl bg-card p-4 shadow-sm">
-          <h2 className="mb-2 text-sm font-medium uppercase tracking-wider text-muted-foreground">
-            Taste Profile
-          </h2>
-          <TasteRadar
-            aroma={brew.aroma}
-            acidity={brew.acidity}
-            sweetness={brew.sweetness}
-            body={brew.body}
-            overall={brew.overall}
-          />
-        </section>
+        {brew.overall > 0 && (
+          <section className="mb-6 rounded-xl bg-card p-4 shadow-sm">
+            <h2 className="mb-2 text-sm font-medium uppercase tracking-wider text-muted-foreground">
+              Taste Profile
+            </h2>
+            <TasteRadar
+              aroma={brew.aroma}
+              acidity={brew.acidity}
+              sweetness={brew.sweetness}
+              body={brew.body}
+              overall={brew.overall}
+            />
+          </section>
+        )}
 
         {/* Flavors */}
         {brew.flavors.length > 0 && (

--- a/app/brews/schema.test.ts
+++ b/app/brews/schema.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { upsertBrewSchema } from '@/app/brews/schema'
+
+const baseDto = {
+  beanId: 'bean-1',
+  beanWeight: 15,
+  beanGrind: 24,
+  waterWeight: 225,
+  waterTemp: 92,
+  steps: [],
+  notes: '',
+  flavorIds: [],
+}
+
+describe('upsertBrewSchema', () => {
+  it('A1: given a complete brew DTO with all cup ratings 0, when parsing, then it succeeds and preserves the zeros', () => {
+    const dto = {
+      ...baseDto,
+      aroma: 0,
+      acidity: 0,
+      sweetness: 0,
+      body: 0,
+      overall: 0,
+    }
+
+    const result = upsertBrewSchema.parse(dto)
+
+    expect(result.aroma).toBe(0)
+    expect(result.acidity).toBe(0)
+    expect(result.sweetness).toBe(0)
+    expect(result.body).toBe(0)
+    expect(result.overall).toBe(0)
+  })
+
+  it('A2: given a DTO with overall: -1, when parsing, then it throws a ZodError (min 0 boundary)', () => {
+    const dto = {
+      ...baseDto,
+      aroma: 0,
+      acidity: 0,
+      sweetness: 0,
+      body: 0,
+      overall: -1,
+    }
+
+    expect(() => upsertBrewSchema.parse(dto)).toThrow()
+  })
+
+  it('A3: given a DTO with overall: 6, when parsing, then it throws a ZodError (max 5 boundary)', () => {
+    const dto = {
+      ...baseDto,
+      aroma: 0,
+      acidity: 0,
+      sweetness: 0,
+      body: 0,
+      overall: 6,
+    }
+
+    expect(() => upsertBrewSchema.parse(dto)).toThrow()
+  })
+})

--- a/app/brews/schema.ts
+++ b/app/brews/schema.ts
@@ -16,11 +16,11 @@ export const upsertBrewSchema = z.object({
     return value === '' ? null : value
   }),
   steps: z.array(brewStepSchema).default([]),
-  aroma: z.coerce.number().int().min(1).max(5),
-  acidity: z.coerce.number().int().min(1).max(5),
-  sweetness: z.coerce.number().int().min(1).max(5),
-  body: z.coerce.number().int().min(1).max(5),
-  overall: z.coerce.number().int().min(1).max(5),
+  aroma: z.coerce.number().int().min(0).max(5),
+  acidity: z.coerce.number().int().min(0).max(5),
+  sweetness: z.coerce.number().int().min(0).max(5),
+  body: z.coerce.number().int().min(0).max(5),
+  overall: z.coerce.number().int().min(0).max(5),
   notes: z.string().trim().default(''),
   flavorIds: z.array(z.string().trim().min(1)).default([]),
 })

--- a/components/brew-card.test.tsx
+++ b/components/brew-card.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { BrewCard } from '@/components/brew-card'
+import type { BrewWithBean } from '@/lib/types'
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode
+    href: string
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+const baseBrew: BrewWithBean = {
+  acidity: 3,
+  aroma: 4,
+  bean: {
+    country: 'Kenya',
+    created: '2026-04-18T00:00:00.000Z',
+    farm: 'Kieni',
+    id: 'bean-1',
+    name: 'Kenya AA',
+    notes: null,
+    process: 'Washed',
+    region: 'Nyeri',
+    roast: 'Light',
+    roaster: 'Glitch',
+    updated: '2026-04-18T00:00:00.000Z',
+    variety: 'SL28',
+  },
+  beanGrind: 24,
+  beanId: 'bean-1',
+  beanWeight: 15,
+  body: 3,
+  created: '2026-04-18T00:00:00.000Z',
+  flavors: [],
+  id: 'brew-1',
+  notes: 'Good',
+  overall: 4,
+  steps: [],
+  sweetness: 4,
+  updated: '2026-04-18T00:00:00.000Z',
+  waterTemp: 92,
+  waterWeight: 225,
+}
+
+describe('BrewCard', () => {
+  // D1: overall === 0 renders "-/5" not "0/5"
+  it('D1: given a BrewWithBean with overall === 0, when BrewCard renders, then the rating label is "-/5" and not "0/5"', () => {
+    const draftBrew: BrewWithBean = {
+      ...baseBrew,
+      aroma: 0,
+      acidity: 0,
+      sweetness: 0,
+      body: 0,
+      overall: 0,
+    }
+
+    render(<BrewCard brew={draftBrew} />)
+
+    // Production code must render "-/5" when overall === 0.
+    // This test will fail (red) until the implementation changes brew-card.tsx.
+    expect(screen.getByText('-/5')).toBeDefined()
+    expect(screen.queryByText('0/5')).toBeNull()
+  })
+
+  // D2: overall === 4 renders "4/5"
+  it('D2: given a BrewWithBean with overall === 4, when BrewCard renders, then the rating label is "4/5"', () => {
+    render(<BrewCard brew={baseBrew} />)
+
+    expect(screen.getByText('4/5')).toBeDefined()
+  })
+})

--- a/components/brew-card.tsx
+++ b/components/brew-card.tsx
@@ -58,7 +58,7 @@ export function BrewCard({ brew, showBeanInfo = true, className }: BrewCardProps
         </div>
         <div className="flex flex-col items-end gap-1 text-right">
           <span className="font-mono text-lg font-medium text-primary">
-            {brew.overall}/5
+            {brew.overall === 0 ? '-' : brew.overall}/5
           </span>
         </div>
       </div>

--- a/components/new-brew-form.test.tsx
+++ b/components/new-brew-form.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NewBrewForm } from '@/components/new-brew-form'
-import type { Bean, Flavor } from '@/lib/types'
+import type { Bean, BrewWithBean, Flavor } from '@/lib/types'
 
 const { pushMock, refreshMock } = vi.hoisted(() => ({
   pushMock: vi.fn(),
@@ -291,5 +291,316 @@ describe('NewBrewForm', () => {
 
     expect(body.beanWeight).toBe(15.5)
     expect(body.waterWeight).toBe(225.3)
+  })
+
+  // B1: Cup section contains "あとで記録" toggle (OFF by default) and sliders + flavor buttons are visible
+  it('B1: given the create mode form renders, when looking at the Cup section, then a toggle labeled "あとで記録" is present and is OFF by default and sliders and flavor buttons are visible', () => {
+    render(<NewBrewForm beans={beans} flavors={flavors} />)
+
+    // The switch must be present. Production code must add aria-label="あとで記録" to the Switch.
+    const toggle = screen.getByRole('switch', { name: 'あとで記録' })
+    expect(toggle).toBeDefined()
+    // Toggle should be unchecked (OFF) by default
+    expect(toggle.getAttribute('data-state')).toBe('unchecked')
+
+    // Sliders are visible (Taste Profile)
+    const sliders = screen.getAllByRole('slider')
+    expect(sliders.length).toBeGreaterThan(0)
+
+    // Flavor Notes buttons are visible
+    expect(screen.getByRole('button', { name: 'Berry' })).toBeDefined()
+  })
+
+  // B2: Toggling "あとで記録" ON hides sliders and flavor buttons but keeps Tasting Notes textarea
+  it('B2: given the create mode form renders, when the user toggles "あとで記録" ON, then sliders and flavor buttons are hidden but Tasting Notes textarea remains visible', () => {
+    render(<NewBrewForm beans={beans} flavors={flavors} />)
+
+    const toggle = screen.getByRole('switch', { name: 'あとで記録' })
+    fireEvent.click(toggle)
+
+    // Sliders should be gone
+    expect(screen.queryAllByRole('slider').length).toBe(0)
+
+    // Flavor buttons should be gone
+    expect(screen.queryByRole('button', { name: 'Berry' })).toBeNull()
+
+    // Tasting Notes textarea must still be present
+    expect(screen.getByPlaceholderText('How was this brew? Any observations?')).toBeDefined()
+  })
+
+  // B3: Submit with toggle ON sends zeroed cup fields and preserves notes
+  it('B3: given the create mode form with toggle ON and recipe fields + notes filled, when submitting, then fetch body has zeroed cup ratings and notes text is preserved', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: async () => ({ id: 'brew-3' }),
+      ok: true,
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<NewBrewForm beans={beans} flavors={flavors} />)
+
+    // Fill recipe fields
+    fireEvent.change(screen.getByRole('combobox', { name: 'Bean' }), {
+      target: { value: 'bean-1' },
+    })
+    fireEvent.change(screen.getByLabelText('Coffee (g)'), { target: { value: '15' } })
+    fireEvent.change(screen.getByLabelText('Water (g)'), { target: { value: '225' } })
+    fillRequiredBrewFields()
+
+    // Fill notes
+    fireEvent.change(screen.getByPlaceholderText('How was this brew? Any observations?'), {
+      target: { value: 'Great draft brew' },
+    })
+
+    // Toggle ON
+    const toggle = screen.getByRole('switch', { name: 'あとで記録' })
+    fireEvent.click(toggle)
+
+    // Submit
+    fireEvent.click(screen.getByRole('button', { name: 'Log Brew' }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    const [, requestInit] = fetchMock.mock.calls[0]
+    const body = JSON.parse((requestInit as RequestInit).body as string) as {
+      aroma: number
+      acidity: number
+      sweetness: number
+      body: number
+      overall: number
+      flavorIds: string[]
+      notes: string
+    }
+
+    expect(body.aroma).toBe(0)
+    expect(body.acidity).toBe(0)
+    expect(body.sweetness).toBe(0)
+    expect(body.body).toBe(0)
+    expect(body.overall).toBe(0)
+    expect(body.flavorIds).toEqual([])
+    expect(body.notes).toBe('Great draft brew')
+  })
+
+  // B4: Submit with toggle OFF (default) sends default slider values and notes
+  it('B4: given the create mode form with toggle OFF and fields filled, when submitting, then the body contains default ratings (4,3,4,3,4) and the notes text', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: async () => ({ id: 'brew-4' }),
+      ok: true,
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<NewBrewForm beans={beans} flavors={flavors} />)
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Bean' }), {
+      target: { value: 'bean-1' },
+    })
+    fireEvent.change(screen.getByLabelText('Coffee (g)'), { target: { value: '15' } })
+    fireEvent.change(screen.getByLabelText('Water (g)'), { target: { value: '225' } })
+    fillRequiredBrewFields()
+
+    fireEvent.change(screen.getByPlaceholderText('How was this brew? Any observations?'), {
+      target: { value: 'Lovely cup' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Log Brew' }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    const [, requestInit] = fetchMock.mock.calls[0]
+    const body = JSON.parse((requestInit as RequestInit).body as string) as {
+      aroma: number
+      acidity: number
+      sweetness: number
+      body: number
+      overall: number
+      notes: string
+    }
+
+    expect(body.aroma).toBe(4)
+    expect(body.acidity).toBe(3)
+    expect(body.sweetness).toBe(4)
+    expect(body.body).toBe(3)
+    expect(body.overall).toBe(4)
+    expect(body.notes).toBe('Lovely cup')
+  })
+
+  // B5: Edit mode with initialBrew.overall === 0 initializes toggle ON and hides sliders
+  it('B5: given edit mode with initialBrew.overall === 0, when the form renders, then the "あとで記録" toggle is ON and sliders are not visible', () => {
+    const draftBrew: BrewWithBean = {
+      acidity: 0,
+      aroma: 0,
+      bean: {
+        country: 'Kenya',
+        created: '2026-04-18T00:00:00.000Z',
+        farm: 'Kieni',
+        id: 'bean-1',
+        name: 'Kenya AA',
+        notes: null,
+        process: 'Washed',
+        region: 'Nyeri',
+        roast: 'Light',
+        roaster: 'Glitch',
+        updated: '2026-04-18T00:00:00.000Z',
+        variety: 'SL28',
+      },
+      beanGrind: 24,
+      beanId: 'bean-1',
+      beanWeight: 15,
+      body: 0,
+      created: '2026-04-18T00:00:00.000Z',
+      flavors: [],
+      id: 'brew-draft',
+      notes: '',
+      overall: 0,
+      steps: [],
+      sweetness: 0,
+      updated: '2026-04-18T00:00:00.000Z',
+      waterTemp: 92,
+      waterWeight: 225,
+    }
+
+    render(<NewBrewForm mode="edit" beans={beans} flavors={flavors} initialBrew={draftBrew} />)
+
+    const toggle = screen.getByRole('switch', { name: 'あとで記録' })
+    expect(toggle.getAttribute('data-state')).toBe('checked')
+
+    // Sliders should be hidden
+    expect(screen.queryAllByRole('slider').length).toBe(0)
+  })
+
+  // B6: Edit mode with initialBrew.overall === 4 initializes toggle OFF and shows sliders with stored values
+  it('B6: given edit mode with initialBrew.overall === 4, when the form renders, then the toggle is OFF and sliders are visible', () => {
+    const normalBrew: BrewWithBean = {
+      acidity: 3,
+      aroma: 4,
+      bean: {
+        country: 'Kenya',
+        created: '2026-04-18T00:00:00.000Z',
+        farm: 'Kieni',
+        id: 'bean-1',
+        name: 'Kenya AA',
+        notes: null,
+        process: 'Washed',
+        region: 'Nyeri',
+        roast: 'Light',
+        roaster: 'Glitch',
+        updated: '2026-04-18T00:00:00.000Z',
+        variety: 'SL28',
+      },
+      beanGrind: 24,
+      beanId: 'bean-1',
+      beanWeight: 15,
+      body: 3,
+      created: '2026-04-18T00:00:00.000Z',
+      flavors: [],
+      id: 'brew-normal',
+      notes: 'Good',
+      overall: 4,
+      steps: [],
+      sweetness: 4,
+      updated: '2026-04-18T00:00:00.000Z',
+      waterTemp: 92,
+      waterWeight: 225,
+    }
+
+    render(<NewBrewForm mode="edit" beans={beans} flavors={flavors} initialBrew={normalBrew} />)
+
+    const toggle = screen.getByRole('switch', { name: 'あとで記録' })
+    expect(toggle.getAttribute('data-state')).toBe('unchecked')
+
+    // Sliders should be visible
+    const sliders = screen.getAllByRole('slider')
+    expect(sliders.length).toBeGreaterThan(0)
+  })
+
+  // B7: Edit mode, initialBrew.overall === 0, user turns toggle OFF and submits — gets default slider values
+  it('B7: given edit mode with initialBrew.overall === 0, when the user turns toggle OFF and submits without touching sliders, then fetch body contains default values aroma=4 acidity=3 sweetness=4 body=3 overall=4', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    // Recipe is complete (steps non-empty so brewTime is pre-populated),
+    // only the cup evaluation is in draft state (all ratings = 0).
+    const draftBrew: BrewWithBean = {
+      acidity: 0,
+      aroma: 0,
+      bean: {
+        country: 'Kenya',
+        created: '2026-04-18T00:00:00.000Z',
+        farm: 'Kieni',
+        id: 'bean-1',
+        name: 'Kenya AA',
+        notes: null,
+        process: 'Washed',
+        region: 'Nyeri',
+        roast: 'Light',
+        roaster: 'Glitch',
+        updated: '2026-04-18T00:00:00.000Z',
+        variety: 'SL28',
+      },
+      beanGrind: 24,
+      beanId: 'bean-1',
+      beanWeight: 15,
+      body: 0,
+      created: '2026-04-18T00:00:00.000Z',
+      flavors: [],
+      id: 'brew-draft',
+      notes: '',
+      overall: 0,
+      steps: [{ time: 120, water: 225 }],
+      sweetness: 0,
+      updated: '2026-04-18T00:00:00.000Z',
+      waterTemp: 92,
+      waterWeight: 225,
+    }
+
+    render(<NewBrewForm mode="edit" beans={beans} flavors={flavors} initialBrew={draftBrew} />)
+
+    // Toggle is ON initially; turn it OFF
+    const toggle = screen.getByRole('switch', { name: 'あとで記録' })
+    fireEvent.click(toggle)
+
+    // Submit without touching sliders
+    fireEvent.click(screen.getByRole('button', { name: 'Save Brew' }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    const [, requestInit] = fetchMock.mock.calls[0]
+    const body = JSON.parse((requestInit as RequestInit).body as string) as {
+      aroma: number
+      acidity: number
+      sweetness: number
+      body: number
+      overall: number
+    }
+
+    expect(body.aroma).toBe(4)
+    expect(body.acidity).toBe(3)
+    expect(body.sweetness).toBe(4)
+    expect(body.body).toBe(3)
+    expect(body.overall).toBe(4)
+  })
+
+  // B8: Clicking the "あとで記録" label text toggles the switch (click area extension)
+  it('B8: given the create mode form, when the user clicks the "あとで記録" label text, then the switch state toggles', () => {
+    render(<NewBrewForm beans={beans} flavors={flavors} />)
+
+    const toggle = screen.getByRole('switch', { name: 'あとで記録' })
+    expect(toggle.getAttribute('data-state')).toBe('unchecked')
+
+    // The visible label text should act as a click target for the switch
+    fireEvent.click(screen.getByText('あとで記録'))
+
+    expect(toggle.getAttribute('data-state')).toBe('checked')
+
+    // Clicking again switches it back
+    fireEvent.click(screen.getByText('あとで記録'))
+    expect(toggle.getAttribute('data-state')).toBe('unchecked')
   })
 })

--- a/components/new-brew-form.tsx
+++ b/components/new-brew-form.tsx
@@ -18,6 +18,7 @@ import type { Bean, BrewWithBean, Flavor } from '@/lib/types'
 import { COUNTRY_FLAGS } from '@/lib/types'
 import { Loader2, Plus, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { Switch } from '@/components/ui/switch'
 import {
   Area,
   AreaChart,
@@ -73,6 +74,25 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
   const [body, setBody] = useState([initialBrew?.body ?? 3])
   const [overall, setOverall] = useState([initialBrew?.overall ?? 4])
 
+  // "Record later" toggle: ON iff in edit mode with overall === 0
+  const [recordLater, setRecordLater] = useState(
+    initialBrew !== undefined ? initialBrew.overall === 0 : false
+  )
+
+  const handleRecordLaterToggle = (checked: boolean) => {
+    // When toggling OFF: if every rating is currently 0, reset to defaults
+    if (!checked) {
+      if (aroma[0] === 0 && acidity[0] === 0 && sweetness[0] === 0 && body[0] === 0 && overall[0] === 0) {
+        setAroma([4])
+        setAcidity([3])
+        setSweetness([4])
+        setBody([3])
+        setOverall([4])
+      }
+    }
+    setRecordLater(checked)
+  }
+
   const toggleFlavor = (flavorId: string) => {
     setSelectedFlavors((prev) =>
       prev.includes(flavorId)
@@ -103,13 +123,13 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
           waterWeight: parseFloat(waterWeight),
           waterTemp: waterTemp ? parseFloat(waterTemp) : '',
           steps,
-          aroma: aroma[0],
-          acidity: acidity[0],
-          sweetness: sweetness[0],
-          body: body[0],
-          overall: overall[0],
+          aroma: recordLater ? 0 : aroma[0],
+          acidity: recordLater ? 0 : acidity[0],
+          sweetness: recordLater ? 0 : sweetness[0],
+          body: recordLater ? 0 : body[0],
+          overall: recordLater ? 0 : overall[0],
           notes,
-          flavorIds: selectedFlavors,
+          flavorIds: recordLater ? [] : selectedFlavors,
         }),
       })
 
@@ -430,64 +450,84 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
         </div>
       </div>
 
-      {/* Taste Ratings */}
+      {/* Cup */}
       <div className="rounded-xl bg-card p-4 shadow-sm">
-        <h2 className="mb-4 text-sm font-medium uppercase tracking-wider text-muted-foreground">
-          Taste Profile
-        </h2>
-        <div className="flex flex-col gap-5">
-          {[
-            { label: 'Aroma', value: aroma, setValue: setAroma },
-            { label: 'Acidity', value: acidity, setValue: setAcidity },
-            { label: 'Sweetness', value: sweetness, setValue: setSweetness },
-            { label: 'Body', value: body, setValue: setBody },
-            { label: 'Overall', value: overall, setValue: setOverall },
-          ].map((rating) => (
-            <div key={rating.label} className="flex flex-col gap-2">
-              <div className="flex items-center justify-between">
-                <Label>{rating.label}</Label>
-                <span className="text-sm text-muted-foreground">
-                  {rating.value[0]} - {ratingLabels[rating.value[0]]}
-                </span>
-              </div>
-              <Slider
-                value={rating.value}
-                onValueChange={rating.setValue}
-                min={1}
-                max={5}
-                step={1}
-              />
-            </div>
-          ))}
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
+            Cup
+          </h2>
+          <Label
+            htmlFor="record-later-toggle"
+            className="cursor-pointer text-sm font-normal text-muted-foreground"
+          >
+            あとで記録
+            <Switch
+              id="record-later-toggle"
+              checked={recordLater}
+              onCheckedChange={handleRecordLaterToggle}
+              aria-label="あとで記録"
+            />
+          </Label>
         </div>
-      </div>
 
-      {/* Flavor Tags */}
-      <div className="rounded-xl bg-card p-4 shadow-sm">
-        <h2 className="mb-4 text-sm font-medium uppercase tracking-wider text-muted-foreground">
-          Flavor Notes
-        </h2>
-        <div className="flex flex-wrap gap-2">
-          {flavors.map((flavor) => {
-            const isSelected = selectedFlavors.includes(flavor.id)
-            return (
-              <button
-                key={flavor.id}
-                type="button"
-                onClick={() => toggleFlavor(flavor.id)}
-                className={cn(
-                  'flex items-center gap-1 rounded-full px-3 py-1.5 text-sm transition-all',
-                  isSelected
-                    ? 'bg-primary text-primary-foreground'
-                    : 'bg-secondary text-secondary-foreground hover:bg-secondary/80'
-                )}
-              >
-                {flavor.name}
-                {isSelected && <X className="h-3 w-3" />}
-              </button>
-            )
-          })}
-        </div>
+        {!recordLater && (
+          <>
+            {/* Taste Profile */}
+            <div className="mb-4 flex flex-col gap-5">
+              {[
+                { label: 'Aroma', value: aroma, setValue: setAroma },
+                { label: 'Acidity', value: acidity, setValue: setAcidity },
+                { label: 'Sweetness', value: sweetness, setValue: setSweetness },
+                { label: 'Body', value: body, setValue: setBody },
+                { label: 'Overall', value: overall, setValue: setOverall },
+              ].map((rating) => (
+                <div key={rating.label} className="flex flex-col gap-2">
+                  <div className="flex items-center justify-between">
+                    <Label>{rating.label}</Label>
+                    <span className="text-sm text-muted-foreground">
+                      {rating.value[0]} - {ratingLabels[rating.value[0]]}
+                    </span>
+                  </div>
+                  <Slider
+                    value={rating.value}
+                    onValueChange={rating.setValue}
+                    min={1}
+                    max={5}
+                    step={1}
+                  />
+                </div>
+              ))}
+            </div>
+
+            {/* Flavor Notes */}
+            <div>
+              <h3 className="mb-4 text-sm font-medium uppercase tracking-wider text-muted-foreground">
+                Flavor Notes
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {flavors.map((flavor) => {
+                  const isSelected = selectedFlavors.includes(flavor.id)
+                  return (
+                    <button
+                      key={flavor.id}
+                      type="button"
+                      onClick={() => toggleFlavor(flavor.id)}
+                      className={cn(
+                        'flex items-center gap-1 rounded-full px-3 py-1.5 text-sm transition-all',
+                        isSelected
+                          ? 'bg-primary text-primary-foreground'
+                          : 'bg-secondary text-secondary-foreground hover:bg-secondary/80'
+                      )}
+                    >
+                      {flavor.name}
+                      {isSelected && <X className="h-3 w-3" />}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          </>
+        )}
       </div>
 
       {/* Notes */}


### PR DESCRIPTION
## Summary

Resolve #63 by letting users save brews without recording the cup evaluation.

- Merge Taste Profile and Flavor Notes into a single **Cup** card with an **「あとで記録」** toggle placed at the right of the section title. Clicking either the toggle or the label text switches the state (Radix `Label` `htmlFor` + `Switch` `id`).
- When the toggle is **ON**, Taste Profile and Flavor Notes are hidden and submit sends `aroma = acidity = sweetness = body = overall = 0` and `flavorIds = []`. The `notes` textarea stays a separate, always-visible section and its text is preserved regardless of toggle state.
- Edit mode initializes the toggle ON iff `initialBrew.overall === 0`. Turning the toggle off on an all-zero brew restores the slider defaults (4, 3, 4, 3, 4) so the user is not stuck staring at slider minimums.
- Detail page hides `TasteRadar` and renders `-/5` when `overall === 0`; brew card renders `-/5` under the same condition.
- Relax Zod validation (`min(1)` → `min(0)`) on the five rating fields. **No DB schema or migration changes** — the draft convention lives at the application layer.

## Design decisions captured in the thread

- Data convention — a brew is a draft iff the five rating fields are zero; the UI only checks `overall === 0` as a lightweight gate (per R7 in requirements Q&A).
- `notes` is preserved through the toggle so the user can leave brewing observations even without a tasting.
- `Total Time` and other recipe inputs remain `required`; only cup evaluation is made optional.

## Test plan

- [x] `pnpm test` — 26 passed (25 existing + B8 added for the label click area)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] Manual verification on `http://localhost:3000/new?type=brew` — toggle hides/shows the correct sections, submit sends expected payload, detail view and brew card render `-/5`, edit mode initializes correctly, clicking the label text toggles the switch.
- [ ] Smoke-test against existing (non-draft) brews to confirm no visual regression on cards or detail pages.

## Follow-ups

- #67 — `waterTemp` / `beanGrind` can render `null°C` / `null` on the detail page. Not introduced by this PR, but surfaces more often once draft flows increase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)