### PR TITLE
fix: remove "Form input only" label from brew form (#48)

### DIFF
--- a/components/new-brew-form.tsx
+++ b/components/new-brew-form.tsx
@@ -323,12 +323,9 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
 
       {/* Extraction Steps */}
       <div className="rounded-xl bg-card p-4 shadow-sm">
-        <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
-            Extraction Steps
-          </h2>
-          <span className="text-xs text-muted-foreground">Form input only</span>
-        </div>
+        <h2 className="mb-4 text-sm font-medium uppercase tracking-wider text-muted-foreground">
+          Extraction Steps
+        </h2>
 
         <div
           className="relative mb-4 h-44 rounded-lg border border-border/60 bg-secondary/20"


### PR DESCRIPTION
## Summary
- Removes the `Form input only` helper span that sat next to the *Extraction Steps* heading in the brew registration form.
- Collapses the now-unnecessary `flex justify-between` wrapper so the heading follows the same convention as the other section headers in `new-brew-form.tsx` (e.g. *Select Bean*, *Parameters*, *Tasting Notes*).

Closes #48

## Test plan
- [x] `pnpm vitest run components/new-brew-form.test.tsx` — 11/11 pass
- [x] `Grep "Form input only"` — no remaining references anywhere in the repo
- [ ] Visual check: open `/new`, confirm the *Extraction Steps* section renders the heading without the helper text and that spacing to the chart below is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)