### PR TITLE
feat: unify parameter input units as inline suffixes (#37)

### DIFF
--- a/components/new-brew-form.test.tsx
+++ b/components/new-brew-form.test.tsx
@@ -188,13 +188,13 @@ const flavors: Flavor[] = [
 ]
 
 function fillRequiredBrewFields() {
-  fireEvent.change(screen.getByLabelText('Temp (°C)'), {
+  fireEvent.change(screen.getByLabelText('Temp'), {
     target: { value: '92' },
   })
-  fireEvent.change(screen.getByLabelText('Grind (clicks)'), {
+  fireEvent.change(screen.getByLabelText('Grind'), {
     target: { value: '24' },
   })
-  fireEvent.change(screen.getByLabelText('Total Time (sec)'), {
+  fireEvent.change(screen.getByLabelText('Total Time'), {
     target: { value: '120' },
   })
 }
@@ -207,8 +207,8 @@ describe('NewBrewForm', () => {
   it('given the weight inputs when the form renders then both fields allow decimal gram entries', () => {
     render(<NewBrewForm beans={beans} flavors={flavors} />)
 
-    const beanWeightInput = screen.getByLabelText('Coffee (g)')
-    const waterWeightInput = screen.getByLabelText('Water (g)')
+    const beanWeightInput = screen.getByLabelText('Coffee')
+    const waterWeightInput = screen.getByLabelText('Water')
 
     expect(beanWeightInput.getAttribute('min')).toBe('1')
     expect(beanWeightInput.getAttribute('step')).toBe('any')
@@ -229,10 +229,10 @@ describe('NewBrewForm', () => {
     fireEvent.change(screen.getByRole('combobox', { name: 'Bean' }), {
       target: { value: 'bean-1' },
     })
-    fireEvent.change(screen.getByLabelText('Coffee (g)'), {
+    fireEvent.change(screen.getByLabelText('Coffee'), {
       target: { value: '1' },
     })
-    fireEvent.change(screen.getByLabelText('Water (g)'), {
+    fireEvent.change(screen.getByLabelText('Water'), {
       target: { value: '3' },
     })
     fillRequiredBrewFields()
@@ -270,10 +270,10 @@ describe('NewBrewForm', () => {
 
     render(<NewBrewForm beans={beans} flavors={flavors} initialBeanId="bean-1" />)
 
-    fireEvent.change(screen.getByLabelText('Coffee (g)'), {
+    fireEvent.change(screen.getByLabelText('Coffee'), {
       target: { value: '15.5' },
     })
-    fireEvent.change(screen.getByLabelText('Water (g)'), {
+    fireEvent.change(screen.getByLabelText('Water'), {
       target: { value: '225.3' },
     })
     fillRequiredBrewFields()
@@ -342,8 +342,8 @@ describe('NewBrewForm', () => {
     fireEvent.change(screen.getByRole('combobox', { name: 'Bean' }), {
       target: { value: 'bean-1' },
     })
-    fireEvent.change(screen.getByLabelText('Coffee (g)'), { target: { value: '15' } })
-    fireEvent.change(screen.getByLabelText('Water (g)'), { target: { value: '225' } })
+    fireEvent.change(screen.getByLabelText('Coffee'), { target: { value: '15' } })
+    fireEvent.change(screen.getByLabelText('Water'), { target: { value: '225' } })
     fillRequiredBrewFields()
 
     // Fill notes
@@ -395,8 +395,8 @@ describe('NewBrewForm', () => {
     fireEvent.change(screen.getByRole('combobox', { name: 'Bean' }), {
       target: { value: 'bean-1' },
     })
-    fireEvent.change(screen.getByLabelText('Coffee (g)'), { target: { value: '15' } })
-    fireEvent.change(screen.getByLabelText('Water (g)'), { target: { value: '225' } })
+    fireEvent.change(screen.getByLabelText('Coffee'), { target: { value: '15' } })
+    fireEvent.change(screen.getByLabelText('Water'), { target: { value: '225' } })
     fillRequiredBrewFields()
 
     fireEvent.change(screen.getByPlaceholderText('How was this brew? Any observations?'), {
@@ -602,5 +602,72 @@ describe('NewBrewForm', () => {
     // Clicking again switches it back
     fireEvent.click(screen.getByText('あとで記録'))
     expect(toggle.getAttribute('data-state')).toBe('unchecked')
+  })
+
+  // U1: All 5 parameter inputs render an inline unit suffix next to the field
+  it('U1: given the Parameters section renders, when inspecting each input wrapper, then a muted unit suffix is present next to the input', () => {
+    render(<NewBrewForm beans={beans} flavors={flavors} />)
+
+    const cases: Array<{ label: string; unit: string }> = [
+      { label: 'Coffee', unit: 'g' },
+      { label: 'Water', unit: 'g' },
+      { label: 'Temp', unit: '°C' },
+      { label: 'Grind', unit: 'clicks' },
+      { label: 'Total Time', unit: 's' },
+    ]
+
+    for (const { label, unit } of cases) {
+      const input = screen.getByLabelText(label) as HTMLInputElement
+      const wrapper = input.parentElement
+      expect(wrapper).not.toBeNull()
+      const suffix = Array.from(wrapper!.querySelectorAll('span')).find(
+        (s) => s.textContent === unit,
+      )
+      expect(suffix, `expected suffix "${unit}" next to ${label}`).toBeDefined()
+    }
+  })
+
+  // U2: Labels no longer carry the "(unit)" parenthetical
+  it('U2: given the Parameters section renders, when reading label text, then labels do not include a parenthesised unit', () => {
+    render(<NewBrewForm beans={beans} flavors={flavors} />)
+
+    for (const label of ['Coffee', 'Water', 'Temp', 'Grind', 'Total Time']) {
+      expect(screen.getByLabelText(label)).toBeDefined()
+    }
+
+    for (const oldLabel of ['Coffee (g)', 'Water (g)', 'Temp (°C)', 'Grind (clicks)', 'Total Time (sec)']) {
+      expect(screen.queryByText(oldLabel)).toBeNull()
+    }
+  })
+
+  // U3: Extraction Steps column headers no longer carry parenthesised units
+  it('U3: given the Extraction Steps section renders, when reading column headers, then they are "Time" and "Water" with no parenthesised units', () => {
+    render(<NewBrewForm beans={beans} flavors={flavors} />)
+
+    expect(screen.getByText('Time')).toBeDefined()
+    expect(screen.getAllByText('Water').length).toBeGreaterThan(0)
+    expect(screen.queryByText('Time (s)')).toBeNull()
+    expect(screen.queryByText('Water (g)')).toBeNull()
+  })
+
+  // U4: Each parameter input wires aria-describedby to its unit suffix
+  it('U4: given the Parameters section renders, when inspecting aria-describedby on each input, then it references the matching unit suffix span', () => {
+    render(<NewBrewForm beans={beans} flavors={flavors} />)
+
+    const cases: Array<{ label: string; unit: string; suffixId: string }> = [
+      { label: 'Coffee', unit: 'g', suffixId: 'beanWeight-unit' },
+      { label: 'Water', unit: 'g', suffixId: 'waterWeight-unit' },
+      { label: 'Temp', unit: '°C', suffixId: 'waterTemp-unit' },
+      { label: 'Grind', unit: 'clicks', suffixId: 'grindSize-unit' },
+      { label: 'Total Time', unit: 's', suffixId: 'brewTime-unit' },
+    ]
+
+    for (const { label, unit, suffixId } of cases) {
+      const input = screen.getByLabelText(label) as HTMLInputElement
+      expect(input.getAttribute('aria-describedby')).toBe(suffixId)
+      const suffix = document.getElementById(suffixId)
+      expect(suffix, `expected <span id="${suffixId}"> to exist`).not.toBeNull()
+      expect(suffix!.textContent).toBe(unit)
+    }
   })
 })

--- a/components/new-brew-form.test.tsx
+++ b/components/new-brew-form.test.tsx
@@ -194,9 +194,6 @@ function fillRequiredBrewFields() {
   fireEvent.change(screen.getByLabelText('Grind'), {
     target: { value: '24' },
   })
-  fireEvent.change(screen.getByLabelText('Total Time'), {
-    target: { value: '120' },
-  })
 }
 
 describe('NewBrewForm', () => {
@@ -523,8 +520,8 @@ describe('NewBrewForm', () => {
     })
     vi.stubGlobal('fetch', fetchMock)
 
-    // Recipe is complete (steps non-empty so brewTime is pre-populated),
-    // only the cup evaluation is in draft state (all ratings = 0).
+    // Recipe is complete (steps non-empty), only the cup evaluation is
+    // in draft state (all ratings = 0).
     const draftBrew: BrewWithBean = {
       acidity: 0,
       aroma: 0,
@@ -613,7 +610,6 @@ describe('NewBrewForm', () => {
       { label: 'Water', unit: 'g' },
       { label: 'Temp', unit: '°C' },
       { label: 'Grind', unit: 'clicks' },
-      { label: 'Total Time', unit: 's' },
     ]
 
     for (const { label, unit } of cases) {
@@ -631,11 +627,11 @@ describe('NewBrewForm', () => {
   it('U2: given the Parameters section renders, when reading label text, then labels do not include a parenthesised unit', () => {
     render(<NewBrewForm beans={beans} flavors={flavors} />)
 
-    for (const label of ['Coffee', 'Water', 'Temp', 'Grind', 'Total Time']) {
+    for (const label of ['Coffee', 'Water', 'Temp', 'Grind']) {
       expect(screen.getByLabelText(label)).toBeDefined()
     }
 
-    for (const oldLabel of ['Coffee (g)', 'Water (g)', 'Temp (°C)', 'Grind (clicks)', 'Total Time (sec)']) {
+    for (const oldLabel of ['Coffee (g)', 'Water (g)', 'Temp (°C)', 'Grind (clicks)']) {
       expect(screen.queryByText(oldLabel)).toBeNull()
     }
   })
@@ -659,7 +655,6 @@ describe('NewBrewForm', () => {
       { label: 'Water', unit: 'g', suffixId: 'waterWeight-unit' },
       { label: 'Temp', unit: '°C', suffixId: 'waterTemp-unit' },
       { label: 'Grind', unit: 'clicks', suffixId: 'grindSize-unit' },
-      { label: 'Total Time', unit: 's', suffixId: 'brewTime-unit' },
     ]
 
     for (const { label, unit, suffixId } of cases) {
@@ -669,5 +664,16 @@ describe('NewBrewForm', () => {
       expect(suffix, `expected <span id="${suffixId}"> to exist`).not.toBeNull()
       expect(suffix!.textContent).toBe(unit)
     }
+  })
+
+  // U5: Total Time input has been removed from the Parameters section
+  it('U5: given the create mode form renders, when looking for a Total Time input, then there is no such labelled field and no brewTime-unit suffix', () => {
+    render(<NewBrewForm beans={beans} flavors={flavors} />)
+
+    expect(screen.queryByLabelText('Total Time')).toBeNull()
+    expect(screen.queryByLabelText('Total Time (sec)')).toBeNull()
+    expect(screen.queryByText('Total Time')).toBeNull()
+    expect(document.getElementById('brewTime-unit')).toBeNull()
+    expect(document.getElementById('brewTime')).toBeNull()
   })
 })

--- a/components/new-brew-form.tsx
+++ b/components/new-brew-form.tsx
@@ -60,7 +60,6 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
   const [waterWeight, setWaterWeight] = useState(initialBrew ? String(initialBrew.waterWeight) : '')
   const [waterTemp, setWaterTemp] = useState(initialBrew?.waterTemp != null ? String(initialBrew.waterTemp) : '')
   const [grindSize, setGrindSize] = useState(initialBrew?.beanGrind != null ? String(initialBrew.beanGrind) : '')
-  const [brewTime, setBrewTime] = useState(initialBrew && initialBrew.steps.length > 0 ? String(initialBrew.steps[initialBrew.steps.length - 1]?.time ?? '') : '')
   const [stepInputs, setStepInputs] = useState<Array<{ time: string; water: string }>>(
     initialBrew && initialBrew.steps.length > 0
       ? initialBrew.steps.map((step) => ({ time: String(step.time), water: String(step.water) }))
@@ -157,7 +156,12 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
     : '-'
 
   const totalWater = Math.max(parseFloat(waterWeight) || 0, 300)
-  const totalTime = Math.max(parseFloat(brewTime) || 0, 300)
+  const totalTime = useMemo(() => {
+    const stepTimes = stepInputs
+      .map((row) => parseFloat(row.time))
+      .filter((value) => Number.isFinite(value))
+    return Math.max(300, ...stepTimes, 0)
+  }, [stepInputs])
   const snapToInterval = (value: number, interval: number) =>
     Math.round(value / interval) * interval
   const clamp = (value: number, min: number, max: number) =>
@@ -307,24 +311,6 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
                 aria-describedby="grindSize-unit"
               />
               <span id="grindSize-unit" className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">clicks</span>
-            </div>
-          </div>
-          <div className="col-span-2 flex flex-col gap-2">
-            <Label htmlFor="brewTime">Total Time</Label>
-            <div className="relative">
-              <Input
-                id="brewTime"
-                type="number"
-                value={brewTime}
-                onChange={(e) => setBrewTime(e.target.value)}
-                min="30"
-                step="5"
-                required
-                placeholder="0"
-                className="pr-8"
-                aria-describedby="brewTime-unit"
-              />
-              <span id="brewTime-unit" className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">s</span>
             </div>
           </div>
         </div>

--- a/components/new-brew-form.tsx
+++ b/components/new-brew-form.tsx
@@ -239,20 +239,25 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
         </h2>
         <div className="grid grid-cols-2 gap-4">
           <div className="flex flex-col gap-2">
-            <Label htmlFor="beanWeight">Coffee (g)</Label>
-            <Input
-              id="beanWeight"
-              type="number"
-              value={beanWeight}
-              onChange={(e) => setBeanWeight(e.target.value)}
-              min="1"
-              step="any"
-              placeholder="0"
-              required
-            />
+            <Label htmlFor="beanWeight">Coffee</Label>
+            <div className="relative">
+              <Input
+                id="beanWeight"
+                type="number"
+                value={beanWeight}
+                onChange={(e) => setBeanWeight(e.target.value)}
+                min="1"
+                step="any"
+                placeholder="0"
+                required
+                className="pr-8"
+                aria-describedby="beanWeight-unit"
+              />
+              <span id="beanWeight-unit" className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">g</span>
+            </div>
           </div>
           <div className="flex flex-col gap-2">
-            <Label htmlFor="waterWeight">Water (g)</Label>
+            <Label htmlFor="waterWeight">Water</Label>
             <div className="relative">
               <Input
                 id="waterWeight"
@@ -264,12 +269,13 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
                 required
                 placeholder="0"
                 className="pr-8"
+                aria-describedby="waterWeight-unit"
               />
-              <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">g</span>
+              <span id="waterWeight-unit" className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">g</span>
             </div>
           </div>
           <div className="flex flex-col gap-2">
-            <Label htmlFor="waterTemp">Temp (°C)</Label>
+            <Label htmlFor="waterTemp">Temp</Label>
             <div className="relative">
               <Input
                 id="waterTemp"
@@ -281,24 +287,30 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
                 required
                 placeholder="0"
                 className="pr-8"
+                aria-describedby="waterTemp-unit"
               />
-              <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">°C</span>
+              <span id="waterTemp-unit" className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">°C</span>
             </div>
           </div>
           <div className="flex flex-col gap-2">
-            <Label htmlFor="grindSize">Grind (clicks)</Label>
-            <Input
-              id="grindSize"
-              type="number"
-              value={grindSize}
-              onChange={(e) => setGrindSize(e.target.value)}
-              min="1"
-              placeholder="clicks"
-              required
-            />
+            <Label htmlFor="grindSize">Grind</Label>
+            <div className="relative">
+              <Input
+                id="grindSize"
+                type="number"
+                value={grindSize}
+                onChange={(e) => setGrindSize(e.target.value)}
+                min="1"
+                placeholder="0"
+                required
+                className="pr-14"
+                aria-describedby="grindSize-unit"
+              />
+              <span id="grindSize-unit" className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">clicks</span>
+            </div>
           </div>
           <div className="col-span-2 flex flex-col gap-2">
-            <Label htmlFor="brewTime">Total Time (sec)</Label>
+            <Label htmlFor="brewTime">Total Time</Label>
             <div className="relative">
               <Input
                 id="brewTime"
@@ -310,8 +322,9 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
                 required
                 placeholder="0"
                 className="pr-8"
+                aria-describedby="brewTime-unit"
               />
-              <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">s</span>
+              <span id="brewTime-unit" className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">s</span>
             </div>
           </div>
         </div>
@@ -382,8 +395,8 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
 
         <div className="space-y-2">
           <div className="grid grid-cols-[1fr_1fr_auto] items-center gap-2 px-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-            <span>Time (s)</span>
-            <span>Water (g)</span>
+            <span>Time</span>
+            <span>Water</span>
             <span />
           </div>
           {stepInputs.map((stepInput, index) => (


### PR DESCRIPTION
Closes #37

## Summary

- Consolidates unit presentation on the brew registration screen: every parameter field now carries its unit as a visual inline suffix inside the input, not as a `(unit)` parenthetical in the label.
- Adds the previously missing inline suffixes for **Coffee (`g`)** and **Grind (`clicks`)**; keeps the existing suffixes on Water and Temp.
- Drops `(unit)` from the Parameters labels and from the Extraction Steps column headers (`Time (s)` → `Time`, `Water (g)` → `Water`).
- Wires each input to its suffix `<span>` via `aria-describedby` so screen readers announce the unit as a description (the visual `<span>` is `pointer-events-none` and would otherwise be silent).
- **Removes the unused `Total Time` input** — it was never persisted (absent from `upsertBrewSchema` and the fetch payload) and only drove the chart X-axis max. `totalTime` is now derived from the step inputs themselves, so the chart auto-scales.

### Field-by-field

| Field | Label (before → after) | Inline suffix |
|---|---|---|
| Coffee | `Coffee (g)` → `Coffee` | **added** `g` |
| Water | `Water (g)` → `Water` | kept `g` |
| Temp | `Temp (°C)` → `Temp` | kept `°C` |
| Grind | `Grind (clicks)` → `Grind` | **added** `clicks` (with `pr-14` to fit) |
| ~~Total Time~~ | — | **removed (UI-only, never persisted)** |

No payload, `id`, `required`, `min`/`max`/`step`, or numeric-parsing changes on the persisted fields. Cup / Flavor Notes / Tasting Notes untouched.

## Test plan

- [x] `npm test -- components/new-brew-form.test.tsx` — 15 tests pass, including 5 new acceptance tests:
  - **U1** — every remaining parameter input renders an inline suffix matching the expected unit.
  - **U2** — labels contain the plain field name; old `(unit)` label strings are absent.
  - **U3** — Extraction Steps column headers are `Time` / `Water`, old `(s)` / `(g)` strings are absent.
  - **U4** — each input's `aria-describedby` points at the matching suffix span id.
  - **U5** — no `Total Time` label, no `brewTime-unit` span, no `brewTime` input exists.
- [x] `npm test` (full suite) — 119/119 pass across 18 files.
- [ ] Manual check on mobile-ish viewport: confirm `Grind` (`pr-14`) does not visually collide `clicks` with typed 3-digit values.
- [ ] Screen-reader smoke test (VoiceOver): field announces as e.g. "Coffee, required number field, g".
- [ ] Manual check: chart X-axis auto-scales as the user adds / changes step times.

## Follow-ups (not in this PR)

- `app/brews/[id]/page.tsx` still renders `Grind (clicks)` in the detail view and `app/brews/[id]/page.test.tsx` asserts that string. Either bring the detail page in line with the new inline-suffix pattern (scope creep beyond #37's "登録画面" wording) or accept the display inconsistency. Recommend filing a separate issue.
- Minor UX roughness: because the chart X-axis now derives from step inputs, the axis may jump as the user types partial values (e.g. typing "3" before "300" collapses to the 300-floor, then expands). Consider a blur-committed or debounced `totalTime` if this becomes noticeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)