### PR TITLE
feat: estimate roast level from bean photo via CIELAB L* curve (#59)

### DIFF
--- a/components/new-bean-form.test.tsx
+++ b/components/new-bean-form.test.tsx
@@ -1,10 +1,15 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NewBeanForm } from '@/components/new-bean-form'
+import type { RoastLevel } from '@/lib/types'
 
 const { pushMock, refreshMock } = vi.hoisted(() => ({
   pushMock: vi.fn(),
   refreshMock: vi.fn(),
+}))
+
+const { photoPickerState } = vi.hoisted(() => ({
+  photoPickerState: { onEstimate: null as ((level: RoastLevel) => void) | null },
 }))
 
 vi.mock('next/navigation', () => ({
@@ -12,6 +17,21 @@ vi.mock('next/navigation', () => ({
     push: pushMock,
     refresh: refreshMock,
   }),
+}))
+
+vi.mock('@/components/roast-photo-picker', () => ({
+  RoastPhotoPicker: ({ onEstimate }: { onEstimate: (level: string) => void }) => {
+    photoPickerState.onEstimate = onEstimate as (level: RoastLevel) => void
+    return (
+      <button
+        type="button"
+        data-testid="mock-photo-picker"
+        onClick={() => onEstimate('French')}
+      >
+        Mock Photo Picker
+      </button>
+    )
+  },
 }))
 
 vi.mock('@/components/ui/select', async () => {
@@ -147,6 +167,7 @@ vi.mock('@/components/ui/select', async () => {
 describe('NewBeanForm', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    photoPickerState.onEstimate = null
   })
 
   it('T8: given the palette selection changes from Medium to French, when the form is submitted, then fetch is called with roast="French"', async () => {
@@ -179,5 +200,68 @@ describe('NewBeanForm', () => {
     const [, requestInit] = fetchMock.mock.calls[0]
     const body = JSON.parse((requestInit as RequestInit).body as string) as { roast: string }
     expect(body.roast).toBe('French')
+  })
+
+  it('S5-T1: given NewBeanForm renders, when rendered, then the RoastPhotoPicker mock is present', () => {
+    render(<NewBeanForm />)
+    expect(screen.getByTestId('mock-photo-picker')).toBeDefined()
+  })
+
+  it('S5-T2: given RoastPhotoPicker calls onEstimate("French"), when the callback fires, then the roast combobox value becomes "French"', async () => {
+    render(<NewBeanForm />)
+
+    fireEvent.click(screen.getByTestId('mock-photo-picker'))
+
+    await waitFor(() => {
+      const combobox = screen.getByRole('combobox', { name: 'Select roast level' }) as HTMLSelectElement
+      expect(combobox.value).toBe('French')
+    })
+  })
+
+  it('S5-T3: given RoastPhotoPicker sets roast to "French" and the form is submitted, when fetch is called, then request body has roast="French"', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: async () => ({ id: 'bean-1' }),
+      ok: true,
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<NewBeanForm />)
+
+    fireEvent.click(screen.getByTestId('mock-photo-picker'))
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Bean' } })
+    fireEvent.change(screen.getByLabelText('Roaster'), { target: { value: 'Test Roaster' } })
+    const comboboxes = screen.getAllByRole('combobox')
+    fireEvent.change(comboboxes[0], { target: { value: 'Ethiopia' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Bean' }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    const [, requestInit] = fetchMock.mock.calls[0]
+    const body = JSON.parse((requestInit as RequestInit).body as string) as { roast: string }
+    expect(body.roast).toBe('French')
+  })
+
+  it('S5-T4: given photoPickerState.onEstimate("Light") is invoked, when called, then the roast combobox value becomes "Light"', async () => {
+    render(<NewBeanForm />)
+
+    await waitFor(() => expect(photoPickerState.onEstimate).not.toBeNull())
+    photoPickerState.onEstimate!('Light')
+
+    await waitFor(() => {
+      const combobox = screen.getByRole('combobox', { name: 'Select roast level' }) as HTMLSelectElement
+      expect(combobox.value).toBe('Light')
+    })
+  })
+
+  it('S5-T5: given NewBeanForm with mode="edit" and an initialBean, when rendered, then the RoastPhotoPicker mock is present', () => {
+    const bean = {
+      id: 'b1', name: 'Test', country: 'Ethiopia' as const, region: null, farm: null,
+      process: null, variety: null, roast: 'Medium' as const, roaster: 'R',
+      notes: null, created: '', updated: '',
+    }
+    render(<NewBeanForm mode="edit" initialBean={bean} />)
+    expect(screen.getByTestId('mock-photo-picker')).toBeDefined()
   })
 })

--- a/components/new-bean-form.tsx
+++ b/components/new-bean-form.tsx
@@ -7,6 +7,7 @@ import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
 import { RoastPalette } from '@/components/roast-palette'
+import { RoastPhotoPicker } from '@/components/roast-photo-picker'
 import {
   Select,
   SelectContent,
@@ -160,6 +161,9 @@ export function NewBeanForm({ mode = 'create', initialBean }: NewBeanFormProps) 
           </div>
           <div className="flex flex-col gap-3">
             <Label>Roast Level</Label>
+            <RoastPhotoPicker
+              onEstimate={(level) => setRoastIndex([ROAST_LEVELS.indexOf(level)])}
+            />
             <RoastPalette
               value={ROAST_LEVELS[roastIndex[0]]}
               onChange={(level) => setRoastIndex([ROAST_LEVELS.indexOf(level)])}

--- a/components/new-bean-form.tsx
+++ b/components/new-bean-form.tsx
@@ -161,13 +161,15 @@ export function NewBeanForm({ mode = 'create', initialBean }: NewBeanFormProps) 
           </div>
           <div className="flex flex-col gap-3">
             <Label>Roast Level</Label>
-            <RoastPhotoPicker
-              onEstimate={(level) => setRoastIndex([ROAST_LEVELS.indexOf(level)])}
-            />
-            <RoastPalette
-              value={ROAST_LEVELS[roastIndex[0]]}
-              onChange={(level) => setRoastIndex([ROAST_LEVELS.indexOf(level)])}
-            />
+            <div className="grid grid-cols-2 gap-2">
+              <RoastPalette
+                value={ROAST_LEVELS[roastIndex[0]]}
+                onChange={(level) => setRoastIndex([ROAST_LEVELS.indexOf(level)])}
+              />
+              <RoastPhotoPicker
+                onEstimate={(level) => setRoastIndex([ROAST_LEVELS.indexOf(level)])}
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/components/roast-palette.tsx
+++ b/components/roast-palette.tsx
@@ -12,7 +12,7 @@ interface RoastPaletteProps {
 export function RoastPalette({ value, onChange }: RoastPaletteProps) {
   return (
     <Select value={value} onValueChange={(v) => onChange(v as RoastLevel)}>
-      <SelectTrigger aria-label="Roast Level">
+      <SelectTrigger aria-label="Roast Level" className="w-full">
         <SelectValue placeholder="Select roast level" />
       </SelectTrigger>
       <SelectContent>

--- a/components/roast-photo-picker.test.tsx
+++ b/components/roast-photo-picker.test.tsx
@@ -1,0 +1,193 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/color/image-sampler', () => ({
+  sampleImageColor: vi.fn(),
+}))
+vi.mock('@/lib/color/srgb-to-lab', () => ({
+  srgbToLab: vi.fn(),
+}))
+vi.mock('@/lib/color/roast-estimator', () => ({
+  estimateRoastLevel: vi.fn(),
+}))
+
+import { RoastPhotoPicker } from '@/components/roast-photo-picker'
+import { sampleImageColor } from '@/lib/color/image-sampler'
+import { srgbToLab } from '@/lib/color/srgb-to-lab'
+import { estimateRoastLevel } from '@/lib/color/roast-estimator'
+
+const mockSampleImageColor = vi.mocked(sampleImageColor)
+const mockSrgbToLab = vi.mocked(srgbToLab)
+const mockEstimateRoastLevel = vi.mocked(estimateRoastLevel)
+
+function makeImageFile(name = 'bean.jpg') {
+  return new File(['dummy'], name, { type: 'image/jpeg' })
+}
+
+describe('RoastPhotoPicker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('S4-T1: given RoastPhotoPicker renders, when rendered, then a file input with accept="image/*" exists', () => {
+    render(<RoastPhotoPicker onEstimate={vi.fn()} />)
+    const input = screen.getByTestId('photo-input') as HTMLInputElement
+    expect(input.type).toBe('file')
+    expect(input.accept).toBe('image/*')
+  })
+
+  it('S4-T2: given a file is selected, when sampleImageColor is pending, then a loading indicator is visible', async () => {
+    let resolve: ((value: { r: number; g: number; b: number }) => void) | undefined
+    mockSampleImageColor.mockReturnValue(new Promise((res) => { resolve = res }))
+
+    render(<RoastPhotoPicker onEstimate={vi.fn()} />)
+    fireEvent.change(screen.getByTestId('photo-input'), {
+      target: { files: [makeImageFile()] },
+    })
+
+    await screen.findByRole('status')
+    // cleanup: resolve the pending promise so test doesn't leak
+    resolve?.({ r: 100, g: 100, b: 100 })
+  })
+
+  it('S4-T3: given sampleImageColor resolves and estimateRoastLevel returns "Medium", when file is selected, then onEstimate is called with "Medium"', async () => {
+    mockSampleImageColor.mockResolvedValue({ r: 158, g: 108, b: 65 })
+    mockSrgbToLab.mockReturnValue({ L: 50.0, a: 12.0, b: 20.0 })
+    mockEstimateRoastLevel.mockReturnValue('Medium')
+
+    const onEstimate = vi.fn()
+    render(<RoastPhotoPicker onEstimate={onEstimate} />)
+
+    fireEvent.change(screen.getByTestId('photo-input'), {
+      target: { files: [makeImageFile()] },
+    })
+
+    await waitFor(() => expect(onEstimate).toHaveBeenCalledTimes(1))
+    expect(onEstimate).toHaveBeenCalledWith('Medium')
+  })
+
+  it('S4-T4: given estimation succeeds, when onEstimate is called, then loading indicator is no longer visible', async () => {
+    mockSampleImageColor.mockResolvedValue({ r: 158, g: 108, b: 65 })
+    mockSrgbToLab.mockReturnValue({ L: 50.0, a: 12.0, b: 20.0 })
+    mockEstimateRoastLevel.mockReturnValue('Medium')
+
+    render(<RoastPhotoPicker onEstimate={vi.fn()} />)
+    fireEvent.change(screen.getByTestId('photo-input'), {
+      target: { files: [makeImageFile()] },
+    })
+
+    await waitFor(() => expect(screen.queryByRole('status')).toBeNull())
+  })
+
+  it('S4-T5: given sampleImageColor rejects, when file is selected, then onEstimate is not called and an error message is visible', async () => {
+    mockSampleImageColor.mockRejectedValue(new Error('canvas error'))
+
+    const onEstimate = vi.fn()
+    render(<RoastPhotoPicker onEstimate={onEstimate} />)
+
+    fireEvent.change(screen.getByTestId('photo-input'), {
+      target: { files: [makeImageFile()] },
+    })
+
+    await screen.findByRole('alert')
+    expect(onEstimate).not.toHaveBeenCalled()
+  })
+
+  it('S4-T6: given estimateRoastLevel returns null (out-of-range), when file is selected, then onEstimate is not called and an error message is visible', async () => {
+    mockSampleImageColor.mockResolvedValue({ r: 255, g: 255, b: 255 })
+    mockSrgbToLab.mockReturnValue({ L: 100.0, a: 0.0, b: 0.0 })
+    mockEstimateRoastLevel.mockReturnValue(null)
+
+    const onEstimate = vi.fn()
+    render(<RoastPhotoPicker onEstimate={onEstimate} />)
+
+    fireEvent.change(screen.getByTestId('photo-input'), {
+      target: { files: [makeImageFile()] },
+    })
+
+    await screen.findByRole('alert')
+    expect(onEstimate).not.toHaveBeenCalled()
+  })
+
+  it('S4-T7: given first estimation succeeds and second fails, when two files are selected sequentially, then only the latest error is visible', async () => {
+    mockSampleImageColor
+      .mockResolvedValueOnce({ r: 158, g: 108, b: 65 })
+      .mockRejectedValueOnce(new Error('second error'))
+    mockSrgbToLab.mockReturnValue({ L: 50.0, a: 12.0, b: 20.0 })
+    mockEstimateRoastLevel.mockReturnValue('Medium')
+
+    render(<RoastPhotoPicker onEstimate={vi.fn()} />)
+    const input = screen.getByTestId('photo-input')
+
+    fireEvent.change(input, { target: { files: [makeImageFile()] } })
+    await waitFor(() => expect(screen.queryByRole('status')).toBeNull())
+
+    fireEvent.change(input, { target: { files: [makeImageFile('second.jpg')] } })
+    await screen.findByRole('alert')
+    expect(screen.getAllByRole('alert')).toHaveLength(1)
+  })
+
+  it('S4-T8: given estimation succeeds with L*=50.0, when file is processed, then L* value "50.0" and level "Medium" are visible', async () => {
+    mockSampleImageColor.mockResolvedValue({ r: 158, g: 108, b: 65 })
+    mockSrgbToLab.mockReturnValue({ L: 50.0, a: 12.0, b: 20.0 })
+    mockEstimateRoastLevel.mockReturnValue('Medium')
+
+    render(<RoastPhotoPicker onEstimate={vi.fn()} />)
+    fireEvent.change(screen.getByTestId('photo-input'), {
+      target: { files: [makeImageFile()] },
+    })
+
+    await screen.findByText(/50\.0/)
+    await screen.findByText(/Medium/)
+  })
+
+  it('S4-T9: given an empty FileList, when the input change event fires, then sampleImageColor is not called', () => {
+    mockSampleImageColor.mockResolvedValue({ r: 0, g: 0, b: 0 })
+    render(<RoastPhotoPicker onEstimate={vi.fn()} />)
+
+    fireEvent.change(screen.getByTestId('photo-input'), {
+      target: { files: [] },
+    })
+
+    expect(mockSampleImageColor).not.toHaveBeenCalled()
+  })
+
+  it('S4-T10: given two files are selected and the first resolves after the second, when both complete, then onEstimate is called only with the latest result (not overwritten by stale)', async () => {
+    let resolveFirst: ((value: { r: number; g: number; b: number }) => void) | undefined
+    let resolveSecond: ((value: { r: number; g: number; b: number }) => void) | undefined
+
+    mockSampleImageColor
+      .mockImplementationOnce(() => new Promise((res) => { resolveFirst = res }))
+      .mockImplementationOnce(() => new Promise((res) => { resolveSecond = res }))
+
+    // second resolves before first, so srgbToLab/estimateRoastLevel are called for second first
+    mockSrgbToLab
+      .mockReturnValueOnce({ L: 38, a: 0, b: 0 })  // second (resolves first)
+      .mockReturnValueOnce({ L: 50, a: 0, b: 0 })  // first (resolves later, stale)
+
+    mockEstimateRoastLevel
+      .mockReturnValueOnce('City')    // second (resolves first)
+      .mockReturnValueOnce('Medium')  // first (resolves later, stale)
+
+    const onEstimate = vi.fn()
+    render(<RoastPhotoPicker onEstimate={onEstimate} />)
+    const input = screen.getByTestId('photo-input')
+
+    // First file selection (will be slow)
+    fireEvent.change(input, { target: { files: [makeImageFile('first.jpg')] } })
+    // Second file selection (will resolve first)
+    fireEvent.change(input, { target: { files: [makeImageFile('second.jpg')] } })
+
+    // Resolve second first, then first
+    resolveSecond?.({ r: 90, g: 60, b: 40 })
+    await waitFor(() => expect(onEstimate).toHaveBeenCalledWith('City'))
+
+    resolveFirst?.({ r: 150, g: 100, b: 70 })
+    // Give microtasks a chance to run
+    await new Promise((r) => setTimeout(r, 0))
+
+    // The stale first result must NOT override the latest City
+    expect(onEstimate).toHaveBeenCalledTimes(1)
+    expect(onEstimate).not.toHaveBeenCalledWith('Medium')
+  })
+})

--- a/components/roast-photo-picker.tsx
+++ b/components/roast-photo-picker.tsx
@@ -74,7 +74,6 @@ export function RoastPhotoPicker({ onEstimate }: RoastPhotoPickerProps) {
       <Button
         type="button"
         variant="outline"
-        size="sm"
         asChild
       >
         <label htmlFor="photo-input" className="cursor-pointer">

--- a/components/roast-photo-picker.tsx
+++ b/components/roast-photo-picker.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { Camera, Loader2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { sampleImageColor } from '@/lib/color/image-sampler'
+import { srgbToLab } from '@/lib/color/srgb-to-lab'
+import { estimateRoastLevel } from '@/lib/color/roast-estimator'
+import type { RoastLevel } from '@/lib/types'
+
+interface RoastPhotoPickerProps {
+  onEstimate: (level: RoastLevel) => void
+}
+
+type Status = 'idle' | 'processing' | 'done' | 'error'
+
+export function RoastPhotoPicker({ onEstimate }: RoastPhotoPickerProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const generationRef = useRef(0)
+  const [status, setStatus] = useState<Status>('idle')
+  const [preview, setPreview] = useState<{ L: number; level: RoastLevel } | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  async function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0]
+    if (!file) return
+
+    const gen = ++generationRef.current
+
+    setStatus('processing')
+    setErrorMessage(null)
+    setPreview(null)
+
+    try {
+      const rgb = await sampleImageColor(file)
+
+      if (gen !== generationRef.current) return
+
+      const lab = srgbToLab(rgb.r, rgb.g, rgb.b)
+      const level = estimateRoastLevel(lab.L)
+
+      if (level === null) {
+        setStatus('error')
+        setErrorMessage('Could not estimate roast level (out of range)')
+        return
+      }
+
+      onEstimate(level)
+      setPreview({ L: lab.L, level })
+      setStatus('done')
+    } catch {
+      if (gen !== generationRef.current) return
+      setStatus('error')
+      setErrorMessage('Could not estimate roast level')
+    } finally {
+      if (inputRef.current) {
+        inputRef.current.value = ''
+      }
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        data-testid="photo-input"
+        className="sr-only"
+        onChange={handleChange}
+        id="photo-input"
+      />
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        asChild
+      >
+        <label htmlFor="photo-input" className="cursor-pointer">
+          <Camera />
+          Estimate from photo
+        </label>
+      </Button>
+
+      {status === 'processing' && (
+        <div role="status" className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="animate-spin" />
+          Estimating roast...
+        </div>
+      )}
+
+      {status === 'done' && preview && (
+        <div role="region" aria-live="polite" aria-label="Estimated roast" className="text-sm text-muted-foreground">
+          <span>L*: {preview.L.toFixed(1)}</span>
+          {' '}
+          <span>{preview.level}</span>
+        </div>
+      )}
+
+      {status === 'error' && errorMessage && (
+        <div role="alert" className="text-sm text-destructive">
+          {errorMessage}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/roast-photo-picker.tsx
+++ b/components/roast-photo-picker.tsx
@@ -42,7 +42,7 @@ export function RoastPhotoPicker({ onEstimate }: RoastPhotoPickerProps) {
 
       if (level === null) {
         setStatus('error')
-        setErrorMessage('Could not estimate roast level (out of range)')
+        setErrorMessage('Out of range')
         return
       }
 
@@ -52,7 +52,7 @@ export function RoastPhotoPicker({ onEstimate }: RoastPhotoPickerProps) {
     } catch {
       if (gen !== generationRef.current) return
       setStatus('error')
-      setErrorMessage('Could not estimate roast level')
+      setErrorMessage("Couldn't detect")
     } finally {
       if (inputRef.current) {
         inputRef.current.value = ''
@@ -79,22 +79,20 @@ export function RoastPhotoPicker({ onEstimate }: RoastPhotoPickerProps) {
       >
         <label htmlFor="photo-input" className="cursor-pointer">
           <Camera />
-          Estimate from photo
+          From photo
         </label>
       </Button>
 
       {status === 'processing' && (
         <div role="status" className="flex items-center gap-2 text-sm text-muted-foreground">
           <Loader2 className="animate-spin" />
-          Estimating roast...
+          Detecting...
         </div>
       )}
 
       {status === 'done' && preview && (
         <div role="region" aria-live="polite" aria-label="Estimated roast" className="text-sm text-muted-foreground">
-          <span>L*: {preview.L.toFixed(1)}</span>
-          {' '}
-          <span>{preview.level}</span>
+          L* {preview.L.toFixed(1)} · {preview.level}
         </div>
       )}
 

--- a/components/roast-photo-picker.tsx
+++ b/components/roast-photo-picker.tsx
@@ -75,6 +75,7 @@ export function RoastPhotoPicker({ onEstimate }: RoastPhotoPickerProps) {
         type="button"
         variant="outline"
         asChild
+        className="w-full"
       >
         <label htmlFor="photo-input" className="cursor-pointer">
           <Camera />

--- a/lib/color/image-sampler.test.ts
+++ b/lib/color/image-sampler.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { sampleImageColor } from '@/lib/color/image-sampler'
+
+function makeImageDataStub(r: number, g: number, b: number, width = 256, height = 256) {
+  const data = new Uint8ClampedArray(width * height * 4)
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = r
+    data[i + 1] = g
+    data[i + 2] = b
+    data[i + 3] = 255
+  }
+  return { data, width, height }
+}
+
+function installCanvasMock(r: number, g: number, b: number) {
+  const getImageDataMock = vi.fn().mockReturnValue(makeImageDataStub(r, g, b))
+  const drawImageMock = vi.fn()
+  const ctx2d = {
+    drawImage: drawImageMock,
+    getImageData: getImageDataMock,
+  }
+  const canvasMock = {
+    width: 0,
+    height: 0,
+    getContext: vi.fn().mockReturnValue(ctx2d),
+  } as unknown as HTMLCanvasElement
+
+  const originalCreate = document.createElement.bind(document)
+  vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+    if (tag === 'canvas') return canvasMock
+    return originalCreate(tag)
+  })
+  return { getImageDataMock, drawImageMock, canvasMock }
+}
+
+function installNullContextCanvasMock() {
+  const canvasMock = {
+    width: 0,
+    height: 0,
+    getContext: vi.fn().mockReturnValue(null),
+  } as unknown as HTMLCanvasElement
+
+  const originalCreate = document.createElement.bind(document)
+  vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+    if (tag === 'canvas') return canvasMock
+    return originalCreate(tag)
+  })
+}
+
+function installImageMock() {
+  class ImageMock {
+    onload: (() => void) | null = null
+    onerror: (() => void) | null = null
+    private _src = ''
+    get src() { return this._src }
+    set src(v: string) {
+      this._src = v
+      queueMicrotask(() => this.onload?.())
+    }
+  }
+  vi.stubGlobal('Image', ImageMock)
+}
+
+describe('sampleImageColor', () => {
+  beforeEach(() => {
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn().mockReturnValue('blob:mock'),
+      revokeObjectURL: vi.fn(),
+    })
+    installImageMock()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('S3-T1: given a uniform image with rgb(186,141,93), when sampleImageColor is called, then returns approx {r:186, g:141, b:93}', async () => {
+    installCanvasMock(186, 141, 93)
+    const file = new File(['dummy'], 'bean.jpg', { type: 'image/jpeg' })
+    const result = await sampleImageColor(file)
+    expect(result.r).toBeCloseTo(186, 0)
+    expect(result.g).toBeCloseTo(141, 0)
+    expect(result.b).toBeCloseTo(93, 0)
+  })
+
+  it('S3-T2: given a uniform image with rgb(61,45,39), when sampleImageColor is called, then returns approx {r:61, g:45, b:39}', async () => {
+    installCanvasMock(61, 45, 39)
+    const file = new File(['dummy'], 'dark.jpg', { type: 'image/jpeg' })
+    const result = await sampleImageColor(file)
+    expect(result.r).toBeCloseTo(61, 0)
+    expect(result.g).toBeCloseTo(45, 0)
+    expect(result.b).toBeCloseTo(39, 0)
+  })
+
+  it('S3-T3: given a file with type "application/pdf", when sampleImageColor is called, then it throws an Error', async () => {
+    const file = new File(['dummy'], 'doc.pdf', { type: 'application/pdf' })
+    await expect(sampleImageColor(file)).rejects.toThrow()
+  })
+
+  it('S3-T4: given a file with empty type, when sampleImageColor is called, then it throws an Error', async () => {
+    const file = new File(['dummy'], 'noext', { type: '' })
+    await expect(sampleImageColor(file)).rejects.toThrow()
+  })
+
+  it('S3-T5: given canvas.getContext returns null, when sampleImageColor is called, then it throws an Error', async () => {
+    installNullContextCanvasMock()
+    const file = new File(['dummy'], 'bean.jpg', { type: 'image/jpeg' })
+    await expect(sampleImageColor(file)).rejects.toThrow()
+  })
+
+  it('S3-T6: given a valid image, when sampleImageColor is called, then getImageData is called with x=77, y=77, w=102, h=102 (centered 40% region)', async () => {
+    const { getImageDataMock } = installCanvasMock(100, 100, 100)
+    const file = new File(['dummy'], 'bean.jpg', { type: 'image/jpeg' })
+    await sampleImageColor(file)
+    const call = getImageDataMock.mock.calls[0]
+    expect(call[0]).toBeGreaterThanOrEqual(76)
+    expect(call[0]).toBeLessThanOrEqual(78)
+    expect(call[1]).toBeGreaterThanOrEqual(76)
+    expect(call[1]).toBeLessThanOrEqual(78)
+    expect(call[2]).toBeGreaterThanOrEqual(101)
+    expect(call[2]).toBeLessThanOrEqual(103)
+    expect(call[3]).toBeGreaterThanOrEqual(101)
+    expect(call[3]).toBeLessThanOrEqual(103)
+  })
+
+  it('S3-T7: given a valid image, when sampleImageColor resolves, then URL.revokeObjectURL is called', async () => {
+    installCanvasMock(100, 100, 100)
+    const file = new File(['dummy'], 'bean.jpg', { type: 'image/jpeg' })
+    await sampleImageColor(file)
+    const urlObj = globalThis.URL as unknown as { revokeObjectURL: ReturnType<typeof vi.fn> }
+    expect(urlObj.revokeObjectURL).toHaveBeenCalled()
+  })
+
+  it('S3-T8: given canvas.getContext returns null, when sampleImageColor rejects, then URL.revokeObjectURL is still called (cleanup)', async () => {
+    installNullContextCanvasMock()
+    const file = new File(['dummy'], 'bean.jpg', { type: 'image/jpeg' })
+    await expect(sampleImageColor(file)).rejects.toThrow()
+    const urlObj = globalThis.URL as unknown as { revokeObjectURL: ReturnType<typeof vi.fn> }
+    expect(urlObj.revokeObjectURL).toHaveBeenCalled()
+  })
+
+  it('S3-T9: given image.onerror fires, when sampleImageColor is called, then it rejects and URL.revokeObjectURL is called', async () => {
+    installCanvasMock(0, 0, 0)
+    // Replace the Image mock to trigger onerror instead of onload
+    class ErrorImageMock {
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+      private _src = ''
+      get src() { return this._src }
+      set src(v: string) {
+        this._src = v
+        queueMicrotask(() => this.onerror?.())
+      }
+    }
+    vi.stubGlobal('Image', ErrorImageMock)
+
+    const file = new File(['dummy'], 'broken.jpg', { type: 'image/jpeg' })
+    await expect(sampleImageColor(file)).rejects.toThrow()
+    const urlObj = globalThis.URL as unknown as { revokeObjectURL: ReturnType<typeof vi.fn> }
+    expect(urlObj.revokeObjectURL).toHaveBeenCalled()
+  })
+})

--- a/lib/color/image-sampler.ts
+++ b/lib/color/image-sampler.ts
@@ -1,0 +1,53 @@
+export async function sampleImageColor(file: File): Promise<{ r: number; g: number; b: number }> {
+  if (!file.type.startsWith('image/')) {
+    throw new Error('Unsupported file type')
+  }
+
+  const url = URL.createObjectURL(file)
+  try {
+    const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const image = new Image()
+      image.onload = () => resolve(image)
+      image.onerror = () => reject(new Error('Failed to load image'))
+      image.src = url
+    })
+
+    const canvas = document.createElement('canvas')
+    canvas.width = 256
+    canvas.height = 256
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) {
+      throw new Error('Failed to get canvas 2d context')
+    }
+
+    ctx.drawImage(img, 0, 0, 256, 256)
+
+    const x = Math.round(256 * 0.30)
+    const y = Math.round(256 * 0.30)
+    const w = Math.round(256 * 0.40)
+    const h = Math.round(256 * 0.40)
+
+    const imageData = ctx.getImageData(x, y, w, h)
+    const { data } = imageData
+
+    let sumR = 0
+    let sumG = 0
+    let sumB = 0
+    const pixelCount = data.length / 4
+
+    for (let i = 0; i < data.length; i += 4) {
+      sumR += data[i]
+      sumG += data[i + 1]
+      sumB += data[i + 2]
+    }
+
+    return {
+      r: sumR / pixelCount,
+      g: sumG / pixelCount,
+      b: sumB / pixelCount,
+    }
+  } finally {
+    URL.revokeObjectURL(url)
+  }
+}

--- a/lib/color/roast-estimator.test.ts
+++ b/lib/color/roast-estimator.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { estimateRoastLevel } from '@/lib/color/roast-estimator'
+import { ROAST_LEVELS } from '@/lib/types'
+
+describe('estimateRoastLevel', () => {
+  it.each([
+    [62, 'Light'],
+    [56, 'Cinnamon'],
+    [50, 'Medium'],
+    [44, 'High'],
+    [38, 'City'],
+    [32, 'Full City'],
+    [26, 'French'],
+    [20, 'Italian'],
+  ] as const)(
+    'S2-T%# given L*=%d (center), when estimateRoastLevel is called, then returns "%s"',
+    (lStar, expected) => {
+      expect(estimateRoastLevel(lStar)).toBe(expected)
+    }
+  )
+
+  it('S2-T9: given L*=65 (upper boundary), when estimateRoastLevel is called, then returns "Light"', () => {
+    expect(estimateRoastLevel(65)).toBe('Light')
+  })
+
+  it('S2-T10: given L*=17 (lower boundary), when estimateRoastLevel is called, then returns "Italian"', () => {
+    expect(estimateRoastLevel(17)).toBe('Italian')
+  })
+
+  it('S2-T11: given L*=65.01 (just above upper boundary), when estimateRoastLevel is called, then returns null', () => {
+    expect(estimateRoastLevel(65.01)).toBeNull()
+  })
+
+  it('S2-T12: given L*=16.99 (just below lower boundary), when estimateRoastLevel is called, then returns null', () => {
+    expect(estimateRoastLevel(16.99)).toBeNull()
+  })
+
+  it('S2-T13: given L*=59 (midpoint Light-Cinnamon), when estimateRoastLevel is called, then returns "Light"', () => {
+    expect(estimateRoastLevel(59)).toBe('Light')
+  })
+
+  it('S2-T14: given L*=58.9 (just past midpoint toward Cinnamon), when estimateRoastLevel is called, then returns "Cinnamon"', () => {
+    expect(estimateRoastLevel(58.9)).toBe('Cinnamon')
+  })
+
+  it('S2-T15: given L*=61.9 (measured from #BA8D5D), when estimateRoastLevel is called, then returns "Light"', () => {
+    expect(estimateRoastLevel(61.9)).toBe('Light')
+  })
+
+  it('S2-T16: given L*=20.11 (measured from #3D2D27), when estimateRoastLevel is called, then returns "Italian"', () => {
+    expect(estimateRoastLevel(20.11)).toBe('Italian')
+  })
+
+  it('S2-T17: given L*=23 (midpoint French-Italian), when estimateRoastLevel is called, then returns "French"', () => {
+    expect(estimateRoastLevel(23)).toBe('French')
+  })
+
+  it('S2-T18: given L*=45 (valid range), when estimateRoastLevel is called, then result is a member of ROAST_LEVELS', () => {
+    const result = estimateRoastLevel(45)
+    expect(result).not.toBeNull()
+    expect(ROAST_LEVELS).toContain(result!)
+  })
+})

--- a/lib/color/roast-estimator.ts
+++ b/lib/color/roast-estimator.ts
@@ -1,0 +1,30 @@
+import { ROAST_LEVELS, type RoastLevel } from '@/lib/types'
+
+export const ROAST_L_STAR: Readonly<Record<RoastLevel, number>> = {
+  Light: 62,
+  Cinnamon: 56,
+  Medium: 50,
+  High: 44,
+  City: 38,
+  'Full City': 32,
+  French: 26,
+  Italian: 20,
+}
+
+export function estimateRoastLevel(lStar: number): RoastLevel | null {
+  if (lStar < 17 || lStar > 65) return null
+
+  let best: RoastLevel = ROAST_LEVELS[0]
+  let bestDiff = Math.abs(lStar - ROAST_L_STAR[best])
+
+  for (let i = 1; i < ROAST_LEVELS.length; i++) {
+    const level = ROAST_LEVELS[i]
+    const diff = Math.abs(lStar - ROAST_L_STAR[level])
+    if (diff < bestDiff) {
+      best = level
+      bestDiff = diff
+    }
+  }
+
+  return best
+}

--- a/lib/color/srgb-to-lab.test.ts
+++ b/lib/color/srgb-to-lab.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { srgbToLab } from '@/lib/color/srgb-to-lab'
+
+describe('srgbToLab', () => {
+  it('S1-T1: given #BA8D5D (Light), when srgbToLab is called, then L* is approx 61.9', () => {
+    const { L } = srgbToLab(0xba, 0x8d, 0x5d)
+    expect(L).toBeCloseTo(61.9, 0)
+  })
+
+  it('S1-T2: given #3D2D27 (Italian), when srgbToLab is called, then L* is approx 20.1', () => {
+    const { L } = srgbToLab(0x3d, 0x2d, 0x27)
+    expect(L).toBeCloseTo(20.1, 1)
+  })
+
+  it('S1-T3: given #9E6C41 (Medium), when srgbToLab is called, then L* is between 49.5 and 50.5', () => {
+    const { L } = srgbToLab(0x9e, 0x6c, 0x41)
+    expect(L).toBeGreaterThanOrEqual(49.5)
+    expect(L).toBeLessThanOrEqual(50.5)
+  })
+
+  it('S1-T4: given white (255,255,255), when srgbToLab is called, then L* is approx 100', () => {
+    const { L } = srgbToLab(255, 255, 255)
+    expect(L).toBeCloseTo(100, 1)
+  })
+
+  it('S1-T5: given black (0,0,0), when srgbToLab is called, then L* is approx 0', () => {
+    const { L } = srgbToLab(0, 0, 0)
+    expect(L).toBeCloseTo(0, 1)
+  })
+
+  it('S1-T6: given a neutral grey (128,128,128), when srgbToLab is called, then a* and b* are approx 0', () => {
+    const { a, b } = srgbToLab(128, 128, 128)
+    expect(a).toBeCloseTo(0, 1)
+    expect(b).toBeCloseTo(0, 1)
+  })
+
+  it('S1-T7: given pure red (255,0,0), when srgbToLab is called, then a* > 0', () => {
+    const { a } = srgbToLab(255, 0, 0)
+    expect(a).toBeGreaterThan(0)
+  })
+
+  it('S1-T8: given any valid input, when srgbToLab is called, then returned object has numeric L, a, b properties', () => {
+    const result = srgbToLab(100, 150, 200)
+    expect(typeof result.L).toBe('number')
+    expect(typeof result.a).toBe('number')
+    expect(typeof result.b).toBe('number')
+  })
+})

--- a/lib/color/srgb-to-lab.ts
+++ b/lib/color/srgb-to-lab.ts
@@ -1,0 +1,51 @@
+export interface Lab {
+  L: number
+  a: number
+  b: number
+}
+
+/**
+ * Converts sRGB (0-255 per channel) to CIELAB (D65 illuminant).
+ *
+ * Pipeline:
+ *   sRGB → linear RGB  (IEC 61966-2-1 inverse gamma)
+ *   linear RGB → XYZ   (sRGB standard matrix, D65)
+ *   XYZ → CIELAB       (D65 white point)
+ */
+export function srgbToLab(r: number, g: number, b: number): Lab {
+  // --- sRGB → linear RGB ---
+  const toLinear = (c: number): number => {
+    const n = c / 255
+    return n <= 0.04045 ? n / 12.92 : ((n + 0.055) / 1.055) ** 2.4
+  }
+
+  const rl = toLinear(r)
+  const gl = toLinear(g)
+  const bl = toLinear(b)
+
+  // --- linear RGB → XYZ (D65) ---
+  const X = 0.4124564 * rl + 0.3575761 * gl + 0.1804375 * bl
+  const Y = 0.2126729 * rl + 0.7151522 * gl + 0.0721750 * bl
+  const Z = 0.0193339 * rl + 0.1191920 * gl + 0.9503041 * bl
+
+  // --- XYZ → CIELAB (D65 white point) ---
+  const Xn = 0.95047
+  const Yn = 1.00000
+  const Zn = 1.08883
+
+  const epsilon = (6 / 29) ** 3 // ~0.008856
+  const kappa = (1 / 3) * (29 / 6) ** 2 // ~7.787
+
+  const f = (t: number): number =>
+    t > epsilon ? t ** (1 / 3) : kappa * t + 4 / 29
+
+  const fx = f(X / Xn)
+  const fy = f(Y / Yn)
+  const fz = f(Z / Zn)
+
+  const L = 116 * fy - 16
+  const a = 500 * (fx - fy)
+  const bStar = 200 * (fy - fz)
+
+  return { L, a, b: bStar }
+}


### PR DESCRIPTION
Closes #59

## Summary
- Add a photo-based roast level estimator to the bean registration form. sRGB → CIELAB(D65) 変換で画像の平均 L* を取り、論文の universal coffee roast color curve に基づき 8 段階 (Light=62 ... Italian=20) に最近接マッピングする。
- 画像処理は完全にクライアントサイドで完結（256×256 canvas の中央 40% 領域平均）。アップロードも保存もしない。blob URL は `finally` で確実に解放。
- 連続ファイル選択時の race condition は `generationRef` でガード。

## Changes
**新規（8 ファイル）**
- `lib/color/srgb-to-lab.ts` + test — IEC 61966-2-1 / D65 準拠の純関数
- `lib/color/roast-estimator.ts` + test — L* (17–65) → RoastLevel、範囲外 null、同点は Light 側優先
- `lib/color/image-sampler.ts` + test — Canvas 中央 40% 領域の平均 sRGB、onerror / null context 対応
- `components/roast-photo-picker.tsx` + test — 自動適用 UI、`aria-live`、race-condition guard

**変更（2 ファイル）**
- `components/new-bean-form.tsx` — `RoastPalette` の直前に `<RoastPhotoPicker>` を追加（create/edit 両対応）
- `components/new-bean-form.test.tsx` — 統合テスト 5 件追加

## Scope
- Out of scope: 豆領域セグメンテーション（中央 40% 平均のみ）、サーバー側画像保存、既存 `ROAST_COLORS` の書き換え、OffscreenCanvas 対応。

## Test plan
- [x] `pnpm test` — 173 passed / 173 (24 test files)
- [x] `pnpm exec tsc --noEmit` — no errors
- [ ] 実機で手動確認: create モードで明るい焙煎豆 → Light 系 / 深煎り豆 → French 系に自動マッピングされることを確認
- [ ] 実機で手動確認: 非画像ファイル（PDF 等）選択時にエラーメッセージが出て、`onEstimate` が呼ばれないこと
- [ ] 実機で手動確認: edit モードでも写真ボタンが表示され、推定値が既存値を上書きすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)