### PR TITLE
feat: user authentication and per-user data isolation (#82)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,12 @@ TURSO_DATABASE_URL=
 TURSO_AUTH_TOKEN=
 ANTHROPIC_API_KEY=
 # ANTHROPIC_MODEL=claude-haiku-4-5  # 省略可: 既定値が使われます
+
+# Auth.js
+AUTH_SECRET=                    # openssl rand -base64 32 で生成。必須。
+AUTH_GOOGLE_ID=                 # Google Cloud Console の OAuth クライアント ID
+AUTH_GOOGLE_SECRET=             # Google Cloud Console の OAuth クライアントシークレット
+
+# Email Magic Link プロバイダ (Resend を使用)
+AUTH_RESEND_KEY=                # Resend API キー
+EMAIL_FROM=noreply@example.com  # 送信元メールアドレス

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from '@/lib/auth'
+
+export const { GET, POST } = handlers

--- a/app/api/beans/[id]/route.test.ts
+++ b/app/api/beans/[id]/route.test.ts
@@ -1,0 +1,220 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getAuthenticatedUserMock, getBeanByIdMock, updateBeanMock, deleteBeanMock } = vi.hoisted(
+  () => ({
+    getAuthenticatedUserMock: vi.fn(),
+    getBeanByIdMock: vi.fn(),
+    updateBeanMock: vi.fn(),
+    deleteBeanMock: vi.fn(),
+  })
+)
+
+vi.mock('@/lib/auth/require-user', () => ({
+  getAuthenticatedUser: getAuthenticatedUserMock,
+}))
+
+vi.mock('@/app/beans/service', () => ({
+  beansService: {
+    getBeanById: getBeanByIdMock,
+    updateBean: updateBeanMock,
+    deleteBean: deleteBeanMock,
+  },
+}))
+
+import { GET, PUT, DELETE } from '@/app/api/beans/[id]/route'
+
+const validBeanBody = {
+  name: 'Ethiopia Yirgacheffe',
+  roaster: 'Glitch',
+  country: 'Ethiopia',
+  region: 'Yirgacheffe',
+  farm: '',
+  variety: 'Heirloom',
+  process: 'Washed',
+  roast: 'Light',
+  notes: '',
+}
+
+const mockBean = {
+  id: 'bean-1',
+  name: 'Ethiopia Yirgacheffe',
+  roaster: 'Glitch',
+  country: 'Ethiopia',
+  region: 'Yirgacheffe',
+  farm: null,
+  variety: 'Heirloom',
+  process: 'Washed',
+  roast: 'Light',
+  notes: null,
+  userId: 'user-1',
+  created: '2026-01-01T00:00:00.000Z',
+  updated: '2026-01-01T00:00:00.000Z',
+}
+
+function createRequest(method: string, url: string, body?: object) {
+  return new Request(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+}
+
+describe('GET /api/beans/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('BID_GET1: 認証なしのとき 401 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue(null)
+
+    const response = await GET(
+      createRequest('GET', 'http://localhost/api/beans/bean-1'),
+      { params: Promise.resolve({ id: 'bean-1' }) }
+    )
+
+    expect(response.status).toBe(401)
+    expect(getBeanByIdMock).not.toHaveBeenCalled()
+  })
+
+  it('BID_GET2: 認証済み + 存在する自分の id のとき 200 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
+    getBeanByIdMock.mockResolvedValue(mockBean)
+
+    const response = await GET(
+      createRequest('GET', 'http://localhost/api/beans/bean-1'),
+      { params: Promise.resolve({ id: 'bean-1' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(getBeanByIdMock).toHaveBeenCalledWith('user-1', 'bean-1')
+  })
+
+  it('B404_GET1: 認証済みだが他ユーザーの bean id を指定したとき 404 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-A',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
+    getBeanByIdMock.mockResolvedValue(undefined)
+
+    const response = await GET(
+      createRequest('GET', 'http://localhost/api/beans/bean-B1'),
+      { params: Promise.resolve({ id: 'bean-B1' }) }
+    )
+
+    expect(response.status).toBe(404)
+    expect(getBeanByIdMock).toHaveBeenCalledWith('user-A', 'bean-B1')
+  })
+})
+
+describe('PUT /api/beans/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('BID_PUT1: 認証なしのとき 401 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue(null)
+
+    const response = await PUT(
+      createRequest('PUT', 'http://localhost/api/beans/bean-1', validBeanBody),
+      { params: Promise.resolve({ id: 'bean-1' }) }
+    )
+
+    expect(response.status).toBe(401)
+    expect(updateBeanMock).not.toHaveBeenCalled()
+  })
+
+  it('BID_PUT2: 認証済み + 有効なボディのとき updateBeanMock が (userId, id, dto) で呼ばれ 200 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
+    updateBeanMock.mockResolvedValue(mockBean)
+
+    const response = await PUT(
+      createRequest('PUT', 'http://localhost/api/beans/bean-1', validBeanBody),
+      { params: Promise.resolve({ id: 'bean-1' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(updateBeanMock).toHaveBeenCalledWith(
+      'user-1',
+      'bean-1',
+      expect.objectContaining({ name: 'Ethiopia Yirgacheffe' })
+    )
+  })
+
+  it('B404_PUT1: 認証済みだが他ユーザーの bean id を指定したとき 404 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-A',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
+    updateBeanMock.mockResolvedValue(undefined)
+
+    const response = await PUT(
+      createRequest('PUT', 'http://localhost/api/beans/bean-B1', validBeanBody),
+      { params: Promise.resolve({ id: 'bean-B1' }) }
+    )
+
+    expect(response.status).toBe(404)
+  })
+})
+
+describe('DELETE /api/beans/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('BID_DEL1: 認証なしのとき 401 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue(null)
+
+    const response = await DELETE(
+      createRequest('DELETE', 'http://localhost/api/beans/bean-1'),
+      { params: Promise.resolve({ id: 'bean-1' }) }
+    )
+
+    expect(response.status).toBe(401)
+    expect(deleteBeanMock).not.toHaveBeenCalled()
+  })
+
+  it('BID_DEL2: 認証済みのとき deleteBeanMock が (userId, id) で呼ばれ 204 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
+    deleteBeanMock.mockResolvedValue(true)
+
+    const response = await DELETE(
+      createRequest('DELETE', 'http://localhost/api/beans/bean-1'),
+      { params: Promise.resolve({ id: 'bean-1' }) }
+    )
+
+    expect(response.status).toBe(204)
+    expect(deleteBeanMock).toHaveBeenCalledWith('user-1', 'bean-1')
+  })
+
+  it('B404_DEL1: 認証済みだが他ユーザーの bean id を指定したとき 404 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-A',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
+    deleteBeanMock.mockResolvedValue(false)
+
+    const response = await DELETE(
+      createRequest('DELETE', 'http://localhost/api/beans/bean-B1'),
+      { params: Promise.resolve({ id: 'bean-B1' }) }
+    )
+
+    expect(response.status).toBe(404)
+  })
+})

--- a/app/api/beans/[id]/route.ts
+++ b/app/api/beans/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { beansService } from '@/app/beans/service'
 import { upsertBeanSchema } from '@/app/beans/schema'
+import { getAuthenticatedUser } from '@/lib/auth/require-user'
 
 export const dynamic = 'force-dynamic'
 
@@ -9,8 +10,13 @@ interface BeanRouteProps {
 }
 
 export async function GET(_: Request, { params }: BeanRouteProps) {
+  const user = await getAuthenticatedUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const { id } = await params
-  const bean = await beansService.getBeanById(id)
+  const bean = await beansService.getBeanById(user.id, id)
 
   if (!bean) {
     return NextResponse.json({ error: 'Bean not found' }, { status: 404 })
@@ -20,6 +26,11 @@ export async function GET(_: Request, { params }: BeanRouteProps) {
 }
 
 export async function PUT(request: Request, { params }: BeanRouteProps) {
+  const user = await getAuthenticatedUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const { id } = await params
   const json = await request.json()
   const parsed = upsertBeanSchema.safeParse(json)
@@ -28,7 +39,7 @@ export async function PUT(request: Request, { params }: BeanRouteProps) {
     return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
   }
 
-  const bean = await beansService.updateBean(id, parsed.data)
+  const bean = await beansService.updateBean(user.id, id, parsed.data)
 
   if (!bean) {
     return NextResponse.json({ error: 'Bean not found' }, { status: 404 })
@@ -38,8 +49,13 @@ export async function PUT(request: Request, { params }: BeanRouteProps) {
 }
 
 export async function DELETE(_: Request, { params }: BeanRouteProps) {
+  const user = await getAuthenticatedUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const { id } = await params
-  const deleted = await beansService.deleteBean(id)
+  const deleted = await beansService.deleteBean(user.id, id)
 
   if (!deleted) {
     return NextResponse.json({ error: 'Bean not found' }, { status: 404 })

--- a/app/api/beans/extract/route.test.ts
+++ b/app/api/beans/extract/route.test.ts
@@ -38,15 +38,20 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { LLMApiError, ExtractionParseError } from '@/lib/llm/errors'
 import { POST } from '@/app/api/beans/extract/route'
 
-// ExtractorService をモック化（route.ts が参照するため先にモック）
-const { extractFromImageMock } = vi.hoisted(() => ({
+// ExtractorService と getAuthenticatedUser をモック化（route.ts が参照するため先にモック）
+const { extractFromImageMock, getAuthenticatedUserMock } = vi.hoisted(() => ({
   extractFromImageMock: vi.fn(),
+  getAuthenticatedUserMock: vi.fn(),
 }))
 
 vi.mock('@/app/beans/extractor/service', () => ({
   extractorService: {
     extractFromImage: extractFromImageMock,
   },
+}))
+
+vi.mock('@/lib/auth/require-user', () => ({
+  getAuthenticatedUser: getAuthenticatedUserMock,
 }))
 
 vi.mock('server-only', () => ({}))
@@ -61,10 +66,33 @@ function makeFile(sizeBytes: number, mimeType = 'image/jpeg', name = 'test.jpg')
   return new File([new Uint8Array(sizeBytes).fill(0xff)], name, { type: mimeType })
 }
 
+// ---- Slice 4: 認証テスト ----
+describe('POST /api/beans/extract — 認証', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('EXT_AUTH1: 認証なしのとき 401 を返す（ファイルが添付されていても）', async () => {
+    getAuthenticatedUserMock.mockResolvedValue(null)
+
+    const file = new File(['fake-image-data'], 'test.jpg', { type: 'image/jpeg' })
+    const response = await POST(makeExtractRequest(file))
+
+    expect(response.status).toBe(401)
+    expect(extractFromImageMock).not.toHaveBeenCalled()
+  })
+})
+
 // ---- Slice 4: バリデーション・正常系テスト ----
 describe('POST /api/beans/extract — バリデーション (skip until route.ts is implemented)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // 認証済み状態をデフォルトに設定（認証テスト以外では認証済みを前提とする）
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
   })
 
   // ---- バリデーション: ファイルなし ----
@@ -155,6 +183,11 @@ describe('POST /api/beans/extract — バリデーション (skip until route.ts
 describe('POST /api/beans/extract — LLM エラー系 (skip until errors.ts files are implemented)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
   })
 
   it('given ExtractorService が LLMApiError をスローするとき then 503 と code: EXTRACTION_FAILED を返す', async () => {
@@ -187,6 +220,15 @@ describe('POST /api/beans/extract — LLM エラー系 (skip until errors.ts fil
 
 // ---- Route のエクスポート確認 ----
 describe('POST /api/beans/extract — Route エクスポート確認 (skip until route.ts is implemented)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
+  })
+
   it('given route モジュールのとき then runtime が "nodejs" としてエクスポートされている', async () => {
     const routeModule = await import('@/app/api/beans/extract/route')
     expect(routeModule.runtime).toBe('nodejs')

--- a/app/api/beans/extract/route.ts
+++ b/app/api/beans/extract/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { extractorService } from '@/app/beans/extractor/service'
 import { InvalidImageError } from '@/app/beans/extractor/errors'
 import { LLMApiError, ExtractionParseError } from '@/lib/llm/errors'
+import { getAuthenticatedUser } from '@/lib/auth/require-user'
 
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
@@ -11,6 +12,11 @@ const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png'] as const
 const SERVER_MAX_SIZE = 4.5 * 1024 * 1024
 
 export async function POST(request: Request): Promise<Response> {
+  const user = await getAuthenticatedUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   let formData: FormData
   try {
     formData = await request.formData()

--- a/app/api/beans/route.test.ts
+++ b/app/api/beans/route.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getAuthenticatedUserMock, getBeansMock, createBeanMock } = vi.hoisted(() => ({
+  getAuthenticatedUserMock: vi.fn(),
+  getBeansMock: vi.fn(),
+  createBeanMock: vi.fn(),
+}))
+
+vi.mock('@/lib/auth/require-user', () => ({
+  getAuthenticatedUser: getAuthenticatedUserMock,
+}))
+
+vi.mock('@/app/beans/service', () => ({
+  beansService: {
+    getBeans: getBeansMock,
+    createBean: createBeanMock,
+  },
+}))
+
+import { GET, POST } from '@/app/api/beans/route'
+
+const validBeanBody = {
+  name: 'Ethiopia Yirgacheffe',
+  roaster: 'Glitch',
+  country: 'Ethiopia',
+  region: 'Yirgacheffe',
+  farm: '',
+  variety: 'Heirloom',
+  process: 'Washed',
+  roast: 'Light',
+  notes: '',
+}
+
+function createRequest(method: string, url: string, body?: object) {
+  return new Request(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+}
+
+describe('GET /api/beans', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('BGET1: 認証なしのとき 401 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue(null)
+
+    const response = await GET()
+
+    expect(response.status).toBe(401)
+    expect(getBeansMock).not.toHaveBeenCalled()
+  })
+
+  it('BGET2: 認証済みのとき beansService.getBeans(userId) を呼び出し 200 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
+    getBeansMock.mockResolvedValue([{ id: 'bean-1', name: 'Ethiopia' }])
+
+    const response = await GET()
+
+    expect(response.status).toBe(200)
+    expect(getBeansMock).toHaveBeenCalledWith('user-1')
+  })
+})
+
+describe('POST /api/beans', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('BPOST1: 認証なしのとき 401 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue(null)
+
+    const response = await POST(
+      createRequest('POST', 'http://localhost/api/beans', validBeanBody)
+    )
+
+    expect(response.status).toBe(401)
+    expect(createBeanMock).not.toHaveBeenCalled()
+  })
+
+  it('BPOST2: 認証済み + 有効なボディのとき beansService.createBean(userId, dto) を呼び出し 201 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
+    createBeanMock.mockResolvedValue({ id: 'bean-new' })
+
+    const response = await POST(
+      createRequest('POST', 'http://localhost/api/beans', validBeanBody)
+    )
+
+    expect(response.status).toBe(201)
+    expect(createBeanMock).toHaveBeenCalledWith(
+      'user-1',
+      expect.objectContaining({ name: 'Ethiopia Yirgacheffe' })
+    )
+  })
+
+  it('BPOST3: 認証済み + 無効なボディのとき 400 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
+
+    const response = await POST(
+      createRequest('POST', 'http://localhost/api/beans', {})
+    )
+
+    expect(response.status).toBe(400)
+  })
+})

--- a/app/api/beans/route.ts
+++ b/app/api/beans/route.ts
@@ -1,10 +1,16 @@
 import { NextResponse } from 'next/server'
 import { beansService } from '@/app/beans/service'
 import { upsertBeanSchema } from '@/app/beans/schema'
+import { getAuthenticatedUser } from '@/lib/auth/require-user'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(request: Request) {
+  const user = await getAuthenticatedUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const json = await request.json()
   const parsed = upsertBeanSchema.safeParse(json)
 
@@ -12,12 +18,17 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
   }
 
-  const bean = await beansService.createBean(parsed.data)
+  const bean = await beansService.createBean(user.id, parsed.data)
 
   return NextResponse.json({ id: bean.id }, { status: 201 })
 }
 
 export async function GET() {
-  const beans = await beansService.getBeans()
+  const user = await getAuthenticatedUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const beans = await beansService.getBeans(user.id)
   return NextResponse.json(beans)
 }

--- a/app/api/brews/[id]/route.test.ts
+++ b/app/api/brews/[id]/route.test.ts
@@ -1,0 +1,244 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getAuthenticatedUserMock, getBrewByIdMock, updateBrewMock, deleteBrewMock } = vi.hoisted(
+  () => ({
+    getAuthenticatedUserMock: vi.fn(),
+    getBrewByIdMock: vi.fn(),
+    updateBrewMock: vi.fn(),
+    deleteBrewMock: vi.fn(),
+  })
+)
+
+vi.mock('@/lib/auth/require-user', () => ({
+  getAuthenticatedUser: getAuthenticatedUserMock,
+}))
+
+vi.mock('@/app/brews/service', () => ({
+  brewsService: {
+    getBrewById: getBrewByIdMock,
+    updateBrew: updateBrewMock,
+    deleteBrew: deleteBrewMock,
+  },
+}))
+
+import { GET, PUT, DELETE } from '@/app/api/brews/[id]/route'
+
+const validBrewBody = {
+  beanId: 'bean-1',
+  beanWeight: 15,
+  beanGrind: 24,
+  waterWeight: 225,
+  waterTemp: 92,
+  steps: [],
+  aroma: 4,
+  acidity: 3,
+  sweetness: 4,
+  body: 3,
+  overall: 4,
+  notes: 'Bright and juicy',
+  flavorIds: [],
+}
+
+const mockBrew = {
+  id: 'brew-1',
+  beanId: 'bean-1',
+  userId: 'user-1',
+  beanWeight: 15,
+  beanGrind: 24,
+  waterWeight: 225,
+  waterTemp: 92,
+  steps: [],
+  aroma: 4,
+  acidity: 3,
+  sweetness: 4,
+  body: 3,
+  overall: 4,
+  notes: 'Bright and juicy',
+  flavors: [],
+  bean: {
+    id: 'bean-1',
+    name: 'Ethiopia',
+    country: 'Ethiopia',
+    roaster: 'Glitch',
+    region: 'Yirgacheffe',
+    farm: null,
+    variety: 'Heirloom',
+    process: 'Washed',
+    roast: 'Light',
+    notes: null,
+    userId: 'user-1',
+    created: '2026-01-01T00:00:00.000Z',
+    updated: '2026-01-01T00:00:00.000Z',
+  },
+  created: '2026-01-01T00:00:00.000Z',
+  updated: '2026-01-01T00:00:00.000Z',
+}
+
+function createRequest(method: string, url: string, body?: object) {
+  return new Request(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+}
+
+describe('GET /api/brews/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('BRW404_GET1: 認証なしのとき 401 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue(null)
+
+    const response = await GET(
+      createRequest('GET', 'http://localhost/api/brews/brew-1'),
+      { params: Promise.resolve({ id: 'brew-1' }) }
+    )
+
+    expect(response.status).toBe(401)
+    expect(getBrewByIdMock).not.toHaveBeenCalled()
+  })
+
+  it('BRW404_GET2: 認証済み + 他ユーザーの brew id のとき 404 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-A',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
+    getBrewByIdMock.mockResolvedValue(undefined)
+
+    const response = await GET(
+      createRequest('GET', 'http://localhost/api/brews/brew-B1'),
+      { params: Promise.resolve({ id: 'brew-B1' }) }
+    )
+
+    expect(response.status).toBe(404)
+    expect(getBrewByIdMock).toHaveBeenCalledWith('user-A', 'brew-B1')
+  })
+
+  it('認証済み + 存在する自分の brew id のとき 200 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
+    getBrewByIdMock.mockResolvedValue(mockBrew)
+
+    const response = await GET(
+      createRequest('GET', 'http://localhost/api/brews/brew-1'),
+      { params: Promise.resolve({ id: 'brew-1' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(getBrewByIdMock).toHaveBeenCalledWith('user-1', 'brew-1')
+  })
+})
+
+describe('PUT /api/brews/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('BRW404_PUT1: 認証なしのとき 401 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue(null)
+
+    const response = await PUT(
+      createRequest('PUT', 'http://localhost/api/brews/brew-1', validBrewBody),
+      { params: Promise.resolve({ id: 'brew-1' }) }
+    )
+
+    expect(response.status).toBe(401)
+    expect(updateBrewMock).not.toHaveBeenCalled()
+  })
+
+  it('BRW404_PUT2: 認証済み + 他ユーザーの brew id のとき 404 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-A',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
+    updateBrewMock.mockResolvedValue(undefined)
+
+    const response = await PUT(
+      createRequest('PUT', 'http://localhost/api/brews/brew-B1', validBrewBody),
+      { params: Promise.resolve({ id: 'brew-B1' }) }
+    )
+
+    expect(response.status).toBe(404)
+  })
+
+  it('認証済み + 有効なボディのとき updateBrewMock が (userId, id, dto) で呼ばれ 200 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
+    updateBrewMock.mockResolvedValue(mockBrew)
+
+    const response = await PUT(
+      createRequest('PUT', 'http://localhost/api/brews/brew-1', validBrewBody),
+      { params: Promise.resolve({ id: 'brew-1' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(updateBrewMock).toHaveBeenCalledWith(
+      'user-1',
+      'brew-1',
+      expect.objectContaining({ beanId: 'bean-1' })
+    )
+  })
+})
+
+describe('DELETE /api/brews/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('BRW404_DEL1: 認証なしのとき 401 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue(null)
+
+    const response = await DELETE(
+      createRequest('DELETE', 'http://localhost/api/brews/brew-1'),
+      { params: Promise.resolve({ id: 'brew-1' }) }
+    )
+
+    expect(response.status).toBe(401)
+    expect(deleteBrewMock).not.toHaveBeenCalled()
+  })
+
+  it('BRW404_DEL2: 認証済み + 他ユーザーの brew id のとき 404 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-A',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
+    deleteBrewMock.mockResolvedValue(false)
+
+    const response = await DELETE(
+      createRequest('DELETE', 'http://localhost/api/brews/brew-B1'),
+      { params: Promise.resolve({ id: 'brew-B1' }) }
+    )
+
+    expect(response.status).toBe(404)
+    expect(deleteBrewMock).toHaveBeenCalledWith('user-A', 'brew-B1')
+  })
+
+  it('認証済みのとき deleteBrewMock が (userId, id) で呼ばれ 204 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
+    deleteBrewMock.mockResolvedValue(true)
+
+    const response = await DELETE(
+      createRequest('DELETE', 'http://localhost/api/brews/brew-1'),
+      { params: Promise.resolve({ id: 'brew-1' }) }
+    )
+
+    expect(response.status).toBe(204)
+    expect(deleteBrewMock).toHaveBeenCalledWith('user-1', 'brew-1')
+  })
+})

--- a/app/api/brews/[id]/route.ts
+++ b/app/api/brews/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { brewsService } from '@/app/brews/service'
 import { upsertBrewSchema } from '@/app/brews/schema'
+import { getAuthenticatedUser } from '@/lib/auth/require-user'
 
 export const dynamic = 'force-dynamic'
 
@@ -9,8 +10,13 @@ interface BrewRouteProps {
 }
 
 export async function GET(_: Request, { params }: BrewRouteProps) {
+  const user = await getAuthenticatedUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const { id } = await params
-  const brew = await brewsService.getBrewById(id)
+  const brew = await brewsService.getBrewById(user.id, id)
 
   if (!brew) {
     return NextResponse.json({ error: 'Brew not found' }, { status: 404 })
@@ -20,6 +26,11 @@ export async function GET(_: Request, { params }: BrewRouteProps) {
 }
 
 export async function PUT(request: Request, { params }: BrewRouteProps) {
+  const user = await getAuthenticatedUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const { id } = await params
   const json = await request.json()
   const parsed = upsertBrewSchema.safeParse(json)
@@ -28,7 +39,7 @@ export async function PUT(request: Request, { params }: BrewRouteProps) {
     return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
   }
 
-  const brew = await brewsService.updateBrew(id, parsed.data)
+  const brew = await brewsService.updateBrew(user.id, id, parsed.data)
 
   if (!brew) {
     return NextResponse.json({ error: 'Brew not found' }, { status: 404 })
@@ -38,8 +49,13 @@ export async function PUT(request: Request, { params }: BrewRouteProps) {
 }
 
 export async function DELETE(_: Request, { params }: BrewRouteProps) {
+  const user = await getAuthenticatedUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const { id } = await params
-  const deleted = await brewsService.deleteBrew(id)
+  const deleted = await brewsService.deleteBrew(user.id, id)
 
   if (!deleted) {
     return NextResponse.json({ error: 'Brew not found' }, { status: 404 })

--- a/app/api/brews/route.test.ts
+++ b/app/api/brews/route.test.ts
@@ -2,19 +2,25 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { createBrewMock } = vi.hoisted(() => ({
+const { createBrewMock, getAuthenticatedUserMock, getBrewsByBeanIdMock } = vi.hoisted(() => ({
   createBrewMock: vi.fn(),
+  getAuthenticatedUserMock: vi.fn(),
+  getBrewsByBeanIdMock: vi.fn(),
 }))
 
 vi.mock('@/app/brews/service', () => ({
   brewsService: {
     createBrew: createBrewMock,
     getBrews: vi.fn(),
-    getBrewsByBeanId: vi.fn(),
+    getBrewsByBeanId: getBrewsByBeanIdMock,
   },
 }))
 
-import { POST } from '@/app/api/brews/route'
+vi.mock('@/lib/auth/require-user', () => ({
+  getAuthenticatedUser: getAuthenticatedUserMock,
+}))
+
+import { GET, POST } from '@/app/api/brews/route'
 
 const validBody = {
   acidity: 3,
@@ -41,17 +47,56 @@ function createRequest(body: object) {
   })
 }
 
+describe('POST /api/brews — 認証', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    createBrewMock.mockResolvedValue({ id: 'brew-1' })
+  })
+
+  it('BREW_AUTH1: 認証なしのとき 401 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue(null)
+
+    const response = await POST(createRequest(validBody))
+
+    expect(response.status).toBe(401)
+    expect(createBrewMock).not.toHaveBeenCalled()
+  })
+
+  it('BREW_AUTH2: 認証済みのとき createBrewMock が userId を第 1 引数として呼ばれる', async () => {
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
+    createBrewMock.mockResolvedValue({ id: 'brew-new' })
+
+    const response = await POST(createRequest(validBody))
+
+    expect(response.status).toBe(201)
+    expect(createBrewMock).toHaveBeenCalledWith(
+      'user-1',
+      expect.objectContaining({ beanId: 'bean-1' })
+    )
+  })
+})
+
 describe('POST /api/brews', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     createBrewMock.mockResolvedValue({ id: 'brew-1' })
+    // 既存テストは認証済み状態をデフォルトに設定
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
   })
 
   it('given odd gram values when the request is valid then it stores the exact weights', async () => {
     const response = await POST(createRequest(validBody))
 
     expect(response.status).toBe(201)
-    expect(createBrewMock).toHaveBeenCalledWith({
+    expect(createBrewMock).toHaveBeenCalledWith('user-1', {
       acidity: 3,
       aroma: 4,
       beanGrind: 24,
@@ -78,7 +123,7 @@ describe('POST /api/brews', () => {
     )
 
     expect(response.status).toBe(201)
-    expect(createBrewMock).toHaveBeenCalledWith({
+    expect(createBrewMock).toHaveBeenCalledWith('user-1', {
       acidity: 3,
       aroma: 4,
       beanGrind: 24,
@@ -126,5 +171,32 @@ describe('POST /api/brews', () => {
 
     expect(response.status).toBe(400)
     expect(createBrewMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /api/brews — クロスユーザー beanId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getBrewsByBeanIdMock.mockResolvedValue([])
+    // user-B として認証済み状態をセット
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-B',
+      email: 'b@example.com',
+      name: 'Bob',
+    })
+  })
+
+  it('BREW_CROSS_USER_BEAN: user-B が user-A の beanId で GET したとき、Service が user-B の userId で呼ばれる', async () => {
+    // Arrange: user-A の beanId を持つリクエストを user-B として送る
+    const userABeanId = 'bean-A1'
+    const request = new Request(`http://localhost/api/brews?beanId=${userABeanId}`)
+
+    // Act
+    const response = await GET(request)
+
+    // Assert: getBrewsByBeanId が user-B の userId と user-A の beanId で呼ばれることを確認
+    // （空配列を返すかどうかは Repository の責任。ここでは引数の伝搬のみ検証）
+    expect(response.status).toBe(200)
+    expect(getBrewsByBeanIdMock).toHaveBeenCalledWith('user-B', userABeanId)
   })
 })

--- a/app/api/brews/route.ts
+++ b/app/api/brews/route.ts
@@ -1,10 +1,16 @@
 import { NextResponse } from 'next/server'
 import { brewsService } from '@/app/brews/service'
 import { upsertBrewSchema } from '@/app/brews/schema'
+import { getAuthenticatedUser } from '@/lib/auth/require-user'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(request: Request) {
+  const user = await getAuthenticatedUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const json = await request.json()
   const parsed = upsertBrewSchema.safeParse(json)
 
@@ -12,20 +18,25 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
   }
 
-  const brew = await brewsService.createBrew(parsed.data)
+  const brew = await brewsService.createBrew(user.id, parsed.data)
 
   return NextResponse.json({ id: brew.id }, { status: 201 })
 }
 
 export async function GET(request: Request) {
+  const user = await getAuthenticatedUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const { searchParams } = new URL(request.url)
   const beanId = searchParams.get('beanId')
 
   if (beanId) {
-    const brews = await brewsService.getBrewsByBeanId(beanId)
+    const brews = await brewsService.getBrewsByBeanId(user.id, beanId)
     return NextResponse.json(brews)
   }
 
-  const brews = await brewsService.getBrews()
+  const brews = await brewsService.getBrews(user.id)
   return NextResponse.json(brews)
 }

--- a/app/api/flavors/route.test.ts
+++ b/app/api/flavors/route.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getAuthenticatedUserMock, getFlavorsServiceMock } = vi.hoisted(() => ({
+  getAuthenticatedUserMock: vi.fn(),
+  getFlavorsServiceMock: vi.fn(),
+}))
+
+vi.mock('@/lib/auth/require-user', () => ({
+  getAuthenticatedUser: getAuthenticatedUserMock,
+}))
+
+vi.mock('@/app/flavors/service', () => ({
+  flavorsService: {
+    getFlavors: getFlavorsServiceMock,
+  },
+}))
+
+import { GET } from '@/app/api/flavors/route'
+
+describe('GET /api/flavors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('FL1: 認証なしのとき 401 を返す', async () => {
+    getAuthenticatedUserMock.mockResolvedValue(null)
+
+    const response = await GET()
+
+    expect(response.status).toBe(401)
+    expect(getFlavorsServiceMock).not.toHaveBeenCalled()
+  })
+
+  it('FL2: 認証済みのとき getFlavors() を呼び出し 200 を返す（userId フィルタなし）', async () => {
+    getAuthenticatedUserMock.mockResolvedValue({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
+    getFlavorsServiceMock.mockResolvedValue([{ id: 'flavor-1', name: 'Citrus' }])
+
+    const response = await GET()
+
+    expect(response.status).toBe(200)
+    // flavors は shared master なので userId を渡さない
+    expect(getFlavorsServiceMock).toHaveBeenCalledWith()
+  })
+})

--- a/app/api/flavors/route.ts
+++ b/app/api/flavors/route.ts
@@ -1,9 +1,15 @@
 import { NextResponse } from 'next/server'
 import { flavorsService } from '@/app/flavors/service'
+import { getAuthenticatedUser } from '@/lib/auth/require-user'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET() {
+  const user = await getAuthenticatedUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const flavors = await flavorsService.getFlavors()
   return NextResponse.json(flavors)
 }

--- a/app/beans/[id]/edit/page.tsx
+++ b/app/beans/[id]/edit/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { ArrowLeft } from 'lucide-react'
 import { beansService } from '@/app/beans/service'
+import { requireUser } from '@/lib/auth/require-user'
 import { NewBeanForm } from '@/components/new-bean-form'
 
 interface EditBeanPageProps {
@@ -9,8 +10,9 @@ interface EditBeanPageProps {
 }
 
 export default async function EditBeanPage({ params }: EditBeanPageProps) {
+  const user = await requireUser()
   const { id } = await params
-  const bean = await beansService.getBeanById(id)
+  const bean = await beansService.getBeanById(user.id, id)
 
   if (!bean) {
     notFound()

--- a/app/beans/[id]/page.tsx
+++ b/app/beans/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { beansService } from '@/app/beans/service'
 import { brewsService } from '@/app/brews/service'
+import { requireUser } from '@/lib/auth/require-user'
 import { COUNTRY_FLAGS } from '@/lib/types'
 import { BrewCard } from '@/components/brew-card'
 import { RoastLevel } from '@/components/roast-level'
@@ -15,14 +16,15 @@ interface BeanDetailPageProps {
 }
 
 export default async function BeanDetailPage({ params }: BeanDetailPageProps) {
+  const user = await requireUser()
   const { id } = await params
-  const bean = await beansService.getBeanById(id)
+  const bean = await beansService.getBeanById(user.id, id)
 
   if (!bean) {
     notFound()
   }
 
-  const brews = await brewsService.getBrewsByBeanId(id)
+  const brews = await brewsService.getBrewsByBeanId(user.id, id)
   const flag = COUNTRY_FLAGS[bean.country]
 
   return (
@@ -31,8 +33,8 @@ export default async function BeanDetailPage({ params }: BeanDetailPageProps) {
       <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur-sm">
         <div className="mx-auto flex h-14 max-w-md items-center justify-between px-4">
           <div className="flex items-center gap-3">
-            <Link 
-              href="/" 
+            <Link
+              href="/"
               className="flex h-8 w-8 items-center justify-center rounded-lg hover:bg-secondary"
             >
               <ArrowLeft className="h-4 w-4" />
@@ -133,7 +135,7 @@ export default async function BeanDetailPage({ params }: BeanDetailPageProps) {
         )}
 
 
-        
+
 
         {/* Brew History */}
         {brews.length > 0 && (

--- a/app/beans/repository.test.ts
+++ b/app/beans/repository.test.ts
@@ -1,0 +1,298 @@
+// @vitest-environment node
+
+import { createClient } from '@libsql/client'
+import { unlinkSync } from 'fs'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+async function setupSchema(client: ReturnType<typeof createClient>) {
+  await client.execute(`PRAGMA foreign_keys = OFF`)
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS "user" (
+      "id" TEXT PRIMARY KEY NOT NULL,
+      "name" TEXT,
+      "email" TEXT NOT NULL UNIQUE,
+      "emailVerified" INTEGER,
+      "image" TEXT
+    )
+  `)
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS "bean" (
+      "id" TEXT PRIMARY KEY NOT NULL,
+      "user_id" TEXT REFERENCES "user"("id"),
+      "name" TEXT NOT NULL DEFAULT '',
+      "country" TEXT NOT NULL DEFAULT '',
+      "region" TEXT,
+      "farm" TEXT,
+      "process" TEXT,
+      "variety" TEXT,
+      "roast" TEXT NOT NULL DEFAULT '',
+      "roaster" TEXT,
+      "notes" TEXT,
+      "created" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updated" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+  `)
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS "brew" (
+      "id" TEXT PRIMARY KEY NOT NULL,
+      "user_id" TEXT REFERENCES "user"("id"),
+      "bean_id" TEXT NOT NULL DEFAULT '',
+      "bean_weight" REAL NOT NULL DEFAULT 0,
+      "bean_grind" REAL,
+      "water_weight" REAL NOT NULL DEFAULT 0,
+      "water_temp" REAL,
+      "steps" TEXT NOT NULL DEFAULT '[]',
+      "aroma" INTEGER NOT NULL DEFAULT 0,
+      "acidity" INTEGER NOT NULL DEFAULT 0,
+      "sweetness" INTEGER NOT NULL DEFAULT 0,
+      "body" INTEGER NOT NULL DEFAULT 0,
+      "overall" INTEGER NOT NULL DEFAULT 0,
+      "notes" TEXT,
+      "created" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updated" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+  `)
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS "brew_flavor" (
+      "id" TEXT PRIMARY KEY NOT NULL,
+      "brew_id" TEXT NOT NULL REFERENCES "brew"("id"),
+      "flavor_id" TEXT NOT NULL,
+      "created" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updated" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+  `)
+}
+
+// vi.hoisted で DB を作成し、vi.mock ファクトリで参照する
+// ':memory:' は drizzle transaction 時に別接続を開くため、テーブルが見えなくなる制約がある。
+// トランザクション後の DB 状態確認が必要なテストのため、一時ファイル DB を使用する。
+const { testDb } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { createClient: _createClient } = require('@libsql/client')
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { drizzle: _drizzle } = require('drizzle-orm/libsql')
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const _os = require('os')
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const _path = require('path')
+  const _dbPath = _path.join(_os.tmpdir(), `beans_repo_test_${Date.now()}.db`)
+  const _client = _createClient({ url: `file:${_dbPath}` })
+  const _db = _drizzle(_client)
+  return { testDb: { client: _client, db: _db, dbPath: _dbPath } }
+})
+
+vi.mock('@/lib/db/drizzle', () => ({
+  db: testDb.db,
+}))
+
+import { BeansRepository } from '@/app/beans/repository'
+
+// テスト終了後に一時ファイルを削除する
+afterAll(() => {
+  try { unlinkSync(testDb.dbPath) } catch { /* ignore */ }
+  try { unlinkSync(testDb.dbPath + '-wal') } catch { /* ignore */ }
+  try { unlinkSync(testDb.dbPath + '-shm') } catch { /* ignore */ }
+})
+
+const validBeanInput = {
+  name: 'Ethiopia Yirgacheffe',
+  country: 'Ethiopia' as const,
+  roast: 'Light' as const,
+  roaster: 'Onibus',
+  region: 'Yirgacheffe',
+  farm: '',
+  process: 'Washed',
+  variety: 'Heirloom',
+  notes: '',
+}
+
+const updatedBeanInput = {
+  name: 'Updated Bean',
+  country: 'Kenya' as const,
+  roast: 'Medium' as const,
+  roaster: 'Glitch',
+  region: 'Nyeri',
+  farm: 'Kieni',
+  process: 'Washed',
+  variety: 'SL28',
+  notes: 'Updated notes',
+}
+
+describe('BeansRepository', () => {
+  let repository: BeansRepository
+
+  beforeEach(async () => {
+    // スキーマをセットアップ（テーブルが既存でも IF NOT EXISTS でスキップ）
+    await setupSchema(testDb.client)
+
+    // テーブルをクリア（各テストの独立性を保つ）
+    await testDb.client.execute(`DELETE FROM brew_flavor`)
+    await testDb.client.execute(`DELETE FROM brew`)
+    await testDb.client.execute(`DELETE FROM bean`)
+
+    // テストデータを仕込む
+    // user-A の bean 2件、user-B の bean 1件
+    await testDb.client.execute({
+      sql: `INSERT INTO bean (id, user_id, name, country, roast) VALUES (?, ?, ?, ?, ?)`,
+      args: ['bean-A1', 'user-A', 'Ethiopia Yirgacheffe', 'Ethiopia', 'Light'],
+    })
+    await testDb.client.execute({
+      sql: `INSERT INTO bean (id, user_id, name, country, roast) VALUES (?, ?, ?, ?, ?)`,
+      args: ['bean-A2', 'user-A', 'Kenya AA', 'Kenya', 'Medium'],
+    })
+    await testDb.client.execute({
+      sql: `INSERT INTO bean (id, user_id, name, country, roast) VALUES (?, ?, ?, ?, ?)`,
+      args: ['bean-B1', 'user-B', 'Colombia Huila', 'Colombia', 'City'],
+    })
+
+    repository = new BeansRepository()
+  })
+
+  describe('findAll(userId)', () => {
+    it('BR_FA1: userId="user-A" のとき user-A の bean のみ返す（user-B の bean は含まれない）', async () => {
+      // Act
+      const beans = await repository.findAll('user-A')
+
+      // Assert
+      expect(beans.length).toBe(2)
+      expect(beans.every((b) => b.userId === 'user-A')).toBe(true)
+      expect(beans.find((b) => b.id === 'bean-B1')).toBeUndefined()
+    })
+
+    it('BR_FA2: 該当ユーザーの bean が 0 件のとき空配列を返す', async () => {
+      // Act
+      const beans = await repository.findAll('user-C')
+
+      // Assert
+      expect(beans.length).toBe(0)
+    })
+  })
+
+  describe('findById(userId, id)', () => {
+    it('BR_FI1: 正しい userId + 存在する id のとき Bean を返す', async () => {
+      // Act
+      const bean = await repository.findById('user-A', 'bean-A1')
+
+      // Assert
+      expect(bean).toBeDefined()
+      expect(bean!.id).toBe('bean-A1')
+      expect(bean!.userId).toBe('user-A')
+    })
+
+    it('BR_FI2: 誤った userId（他ユーザーの bean id）のとき undefined を返す', async () => {
+      // Act
+      const bean = await repository.findById('user-A', 'bean-B1')
+
+      // Assert
+      expect(bean).toBeUndefined()
+    })
+
+    it('BR_FI3: 存在しない id のとき undefined を返す', async () => {
+      // Act
+      const bean = await repository.findById('user-A', 'nonexistent-id')
+
+      // Assert
+      expect(bean).toBeUndefined()
+    })
+  })
+
+  describe('create(userId, input)', () => {
+    it('BR_CR1: create を呼び出すと DB 行に userId が設定される', async () => {
+      // Act
+      const bean = await repository.create('user-A', validBeanInput)
+
+      // Assert: 返り値に userId が含まれる
+      expect(bean.userId).toBe('user-A')
+
+      // Assert: Repository の findById で確認（create は transaction なし db.insert を使うため確認可能）
+      const found = await repository.findById('user-A', bean.id)
+      expect(found).toBeDefined()
+      expect(found!.userId).toBe('user-A')
+    })
+  })
+
+  describe('update(userId, id, input)', () => {
+    it('BR_UP1: 正しい userId のとき Bean を更新して返す', async () => {
+      // Act
+      const bean = await repository.update('user-A', 'bean-A1', updatedBeanInput)
+
+      // Assert
+      expect(bean).toBeDefined()
+      expect(bean!.name).toBe('Updated Bean')
+    })
+
+    it('BR_UP2: 他ユーザーの bean id を指定したとき undefined を返す（行が変更されない）', async () => {
+      // Act
+      const bean = await repository.update('user-A', 'bean-B1', updatedBeanInput)
+
+      // Assert: undefined が返る（BeansRepository.update は transaction なし db.update を使う）
+      expect(bean).toBeUndefined()
+
+      // Assert: Repository 経由で bean-B1 の内容が変わっていないことを確認
+      const unchanged = await repository.findById('user-B', 'bean-B1')
+      expect(unchanged).toBeDefined()
+      expect(unchanged!.name).toBe('Colombia Huila')
+    })
+  })
+
+  describe('delete(userId, id)', () => {
+    it('BR_DE1: 正しい userId のとき true を返し行が削除される', async () => {
+      // Act
+      const result = await repository.delete('user-A', 'bean-A1')
+
+      // Assert: true が返ることで「削除された」ことを確認
+      // （BeansRepository.delete は db.transaction を使うため、commit 後の db.select は
+      // @libsql/client :memory: の制約で別接続から参照できないため戻り値のみで確認する）
+      expect(result).toBe(true)
+    })
+
+    it('BR_DE2: 他ユーザーの bean id を指定したとき false を返す（行が削除されない）', async () => {
+      // Act
+      const result = await repository.delete('user-A', 'bean-B1')
+
+      // Assert: false が返ることで「削除されなかった」ことを確認
+      expect(result).toBe(false)
+    })
+
+    it('BR_DE_CROSS_USER: user-B が user-A の bean を削除しようとしたとき、bean・brew・brew_flavor 行がすべて残る', async () => {
+      // Arrange: user-A の bean-A1 に紐づく brew と brew_flavor をシード
+      await testDb.client.execute({
+        sql: `INSERT INTO brew (id, user_id, bean_id, bean_weight, water_weight, steps, aroma, acidity, sweetness, body, overall) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        args: ['brew-A1', 'user-A', 'bean-A1', 15, 240, '[]', 3, 3, 3, 3, 3],
+      })
+      await testDb.client.execute({
+        sql: `INSERT INTO brew_flavor (id, brew_id, flavor_id) VALUES (?, ?, ?)`,
+        args: ['bf-A1', 'brew-A1', 'flavor-citrus'],
+      })
+
+      // Act: user-B として user-A の bean を削除しようとする
+      const result = await repository.delete('user-B', 'bean-A1')
+
+      // Assert 1: 戻り値が false（所有権なしなので削除失敗）
+      expect(result).toBe(false)
+
+      // Assert 2: user-A の bean 行が DB に残っている
+      const beanRows = await testDb.client.execute({
+        sql: `SELECT id FROM bean WHERE id = ?`,
+        args: ['bean-A1'],
+      })
+      expect(beanRows.rows.length).toBe(1)
+
+      // Assert 3: user-A の brew 行が DB に残っている
+      const brewRows = await testDb.client.execute({
+        sql: `SELECT id FROM brew WHERE id = ?`,
+        args: ['brew-A1'],
+      })
+      expect(brewRows.rows.length).toBe(1)
+
+      // Assert 4: user-A の brew_flavor 行が DB に残っている
+      const flavorRows = await testDb.client.execute({
+        sql: `SELECT id FROM brew_flavor WHERE brew_id = ?`,
+        args: ['brew-A1'],
+      })
+      expect(flavorRows.rows.length).toBe(1)
+    })
+  })
+})

--- a/app/beans/repository.ts
+++ b/app/beans/repository.ts
@@ -1,6 +1,6 @@
 import 'server-only'
 
-import { desc, eq } from 'drizzle-orm'
+import { and, desc, eq } from 'drizzle-orm'
 import type { Bean } from '@/lib/types'
 import { db } from '@/lib/db/drizzle'
 import { beansTable, brewFlavorsTable, brewsTable } from '@/lib/db/schema'
@@ -19,60 +19,72 @@ export interface BeanMutationInput {
 
 function mapBeanRow(row: typeof beansTable.$inferSelect): Bean {
   return {
-    ...row,
+    id: row.id,
+    userId: row.userId ?? null,
+    name: row.name,
     country: row.country as Bean['country'],
+    region: row.region ?? null,
+    farm: row.farm ?? null,
+    process: row.process ?? null,
+    variety: row.variety ?? null,
     roast: row.roast as Bean['roast'],
+    roaster: row.roaster ?? null,
+    notes: row.notes ?? null,
+    created: row.created,
+    updated: row.updated,
   }
 }
 
 export class BeansRepository {
-  async findAll(): Promise<Bean[]> {
+  async findAll(userId: string): Promise<Bean[]> {
     const rows = await db
       .select()
       .from(beansTable)
+      .where(eq(beansTable.userId, userId))
       .orderBy(desc(beansTable.updated))
 
     return rows.map(mapBeanRow)
   }
 
-  async findById(id: string): Promise<Bean | undefined> {
+  async findById(userId: string, id: string): Promise<Bean | undefined> {
     const [row] = await db
       .select()
       .from(beansTable)
-      .where(eq(beansTable.id, id))
+      .where(and(eq(beansTable.userId, userId), eq(beansTable.id, id)))
       .limit(1)
 
     return row ? mapBeanRow(row) : undefined
   }
 
-  async create(input: BeanMutationInput): Promise<Bean> {
+  async create(userId: string, input: BeanMutationInput): Promise<Bean> {
     const [row] = await db
       .insert(beansTable)
-      .values(input)
+      .values({ ...input, userId })
       .returning()
 
     return mapBeanRow(row)
   }
 
-  async update(id: string, input: BeanMutationInput): Promise<Bean | undefined> {
+  async update(userId: string, id: string, input: BeanMutationInput): Promise<Bean | undefined> {
     const [row] = await db
       .update(beansTable)
       .set({
         ...input,
         updated: new Date().toISOString(),
       })
-      .where(eq(beansTable.id, id))
+      .where(and(eq(beansTable.userId, userId), eq(beansTable.id, id)))
       .returning()
 
     return row ? mapBeanRow(row) : undefined
   }
 
-  async delete(id: string): Promise<boolean> {
+  async delete(userId: string, id: string): Promise<boolean> {
     const deleted = await db.transaction(async (tx) => {
+      // userId スコープで brew を取得（他ユーザーの brew を誤って消さないための防御的二重条件）
       const brewRows = await tx
         .select({ id: brewsTable.id })
         .from(brewsTable)
-        .where(eq(brewsTable.beanId, id))
+        .where(and(eq(brewsTable.beanId, id), eq(brewsTable.userId, userId)))
 
       if (brewRows.length > 0) {
         const brewIds = brewRows.map((row) => row.id)
@@ -92,7 +104,7 @@ export class BeansRepository {
 
       const result = await tx
         .delete(beansTable)
-        .where(eq(beansTable.id, id))
+        .where(and(eq(beansTable.userId, userId), eq(beansTable.id, id)))
         .returning({ id: beansTable.id })
 
       return result.length > 0

--- a/app/beans/service.ts
+++ b/app/beans/service.ts
@@ -6,16 +6,16 @@ import type { UpsertBeanDto } from '@/app/beans/schema'
 const beansRepository = new BeansRepository()
 
 export class BeansService {
-  async getBeans() {
-    return beansRepository.findAll()
+  async getBeans(userId: string) {
+    return beansRepository.findAll(userId)
   }
 
-  async getBeanById(id: string) {
-    return beansRepository.findById(id)
+  async getBeanById(userId: string, id: string) {
+    return beansRepository.findById(userId, id)
   }
 
-  async createBean(dto: UpsertBeanDto) {
-    return beansRepository.create({
+  async createBean(userId: string, dto: UpsertBeanDto) {
+    return beansRepository.create(userId, {
       name: dto.name,
       roaster: dto.roaster,
       country: dto.country,
@@ -28,8 +28,8 @@ export class BeansService {
     })
   }
 
-  async updateBean(id: string, dto: UpsertBeanDto) {
-    return beansRepository.update(id, {
+  async updateBean(userId: string, id: string, dto: UpsertBeanDto) {
+    return beansRepository.update(userId, id, {
       name: dto.name,
       roaster: dto.roaster,
       country: dto.country,
@@ -42,8 +42,8 @@ export class BeansService {
     })
   }
 
-  async deleteBean(id: string) {
-    return beansRepository.delete(id)
+  async deleteBean(userId: string, id: string) {
+    return beansRepository.delete(userId, id)
   }
 }
 

--- a/app/brews/[id]/edit/page.tsx
+++ b/app/brews/[id]/edit/page.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft } from 'lucide-react'
 import { brewsService } from '@/app/brews/service'
 import { beansService } from '@/app/beans/service'
 import { flavorsService } from '@/app/flavors/service'
+import { requireUser } from '@/lib/auth/require-user'
 import { NewBrewForm } from '@/components/new-brew-form'
 
 interface EditBrewPageProps {
@@ -11,15 +12,16 @@ interface EditBrewPageProps {
 }
 
 export default async function EditBrewPage({ params }: EditBrewPageProps) {
+  const user = await requireUser()
   const { id } = await params
-  const brew = await brewsService.getBrewById(id)
+  const brew = await brewsService.getBrewById(user.id, id)
 
   if (!brew) {
     notFound()
   }
 
   const [beans, flavors] = await Promise.all([
-    beansService.getBeans(),
+    beansService.getBeans(user.id),
     flavorsService.getFlavors(),
   ])
 

--- a/app/brews/[id]/page.test.tsx
+++ b/app/brews/[id]/page.test.tsx
@@ -3,12 +3,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import BrewDetailPage from '@/app/brews/[id]/page'
 import type { BrewWithBean } from '@/lib/types'
 
-const { getBrewByIdMock, notFoundMock, pourChartSpy, pushMock, refreshMock } = vi.hoisted(() => ({
-  getBrewByIdMock: vi.fn(),
-  notFoundMock: vi.fn(),
-  pourChartSpy: vi.fn(),
-  pushMock: vi.fn(),
-  refreshMock: vi.fn(),
+const { getBrewByIdMock, notFoundMock, pourChartSpy, pushMock, refreshMock, requireUserMock } =
+  vi.hoisted(() => ({
+    getBrewByIdMock: vi.fn(),
+    notFoundMock: vi.fn(),
+    pourChartSpy: vi.fn(),
+    pushMock: vi.fn(),
+    refreshMock: vi.fn(),
+    requireUserMock: vi.fn(),
+  }))
+
+vi.mock('@/lib/auth/require-user', () => ({
+  requireUser: requireUserMock,
 }))
 
 vi.mock('@/app/brews/service', () => ({
@@ -66,6 +72,7 @@ const brew: BrewWithBean = {
     roast: 'Light',
     roaster: 'Glitch',
     updated: '2026-04-18T00:00:00.000Z',
+    userId: null,
     variety: 'SL28',
   },
   beanGrind: 24,
@@ -83,6 +90,7 @@ const brew: BrewWithBean = {
   ],
   sweetness: 4,
   updated: '2026-04-18T00:00:00.000Z',
+  userId: null,
   waterTemp: 92,
   waterWeight: 103,
 }
@@ -91,6 +99,11 @@ describe('BrewDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     getBrewByIdMock.mockResolvedValue(brew)
+    requireUserMock.mockResolvedValue({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
   })
 
   it('given stored odd gram values when the page renders then it shows the exact values and derived ratio', async () => {

--- a/app/brews/[id]/page.tsx
+++ b/app/brews/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { brewsService } from '@/app/brews/service'
+import { requireUser } from '@/lib/auth/require-user'
 import { COUNTRY_FLAGS } from '@/lib/types'
 import { TasteRadar } from '@/components/taste-radar'
 import { PourChart } from '@/components/pour-chart'
@@ -14,8 +15,9 @@ interface BrewDetailPageProps {
 }
 
 export default async function BrewDetailPage({ params }: BrewDetailPageProps) {
+  const user = await requireUser()
   const { id } = await params
-  const brew = await brewsService.getBrewById(id)
+  const brew = await brewsService.getBrewById(user.id, id)
 
   if (!brew) {
     notFound()
@@ -30,8 +32,8 @@ export default async function BrewDetailPage({ params }: BrewDetailPageProps) {
       <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur-sm">
         <div className="mx-auto flex h-14 max-w-md items-center justify-between px-4">
           <div className="flex items-center gap-3">
-            <Link 
-              href={`/beans/${brew.bean.id}`} 
+            <Link
+              href={`/beans/${brew.bean.id}`}
               className="flex h-8 w-8 items-center justify-center rounded-lg hover:bg-secondary"
             >
               <ArrowLeft className="h-4 w-4" />
@@ -64,7 +66,7 @@ export default async function BrewDetailPage({ params }: BrewDetailPageProps) {
 
       <main className="mx-auto max-w-md px-4 py-6">
         {/* Bean Reference */}
-        <Link 
+        <Link
           href={`/beans/${brew.bean.id}`}
           className="mb-6 flex items-center gap-4 rounded-xl bg-card p-4 shadow-sm transition-all hover:shadow-md"
         >
@@ -131,7 +133,7 @@ export default async function BrewDetailPage({ params }: BrewDetailPageProps) {
         </section>
 
 
-        
+
 
         {/* Pour Profile */}
         <section className="mb-6">
@@ -162,7 +164,7 @@ export default async function BrewDetailPage({ params }: BrewDetailPageProps) {
             </h2>
             <div className="flex flex-wrap gap-2">
               {brew.flavors.map((flavor) => (
-                <span 
+                <span
                   key={flavor.id}
                   className="rounded-full bg-secondary px-3 py-1.5 text-sm text-secondary-foreground"
                 >

--- a/app/brews/repository.test.ts
+++ b/app/brews/repository.test.ts
@@ -1,0 +1,312 @@
+// @vitest-environment node
+
+import { createClient } from '@libsql/client'
+import { unlinkSync } from 'fs'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+async function setupSchema(client: ReturnType<typeof createClient>) {
+  await client.execute(`PRAGMA foreign_keys = OFF`)
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS "user" (
+      "id" TEXT PRIMARY KEY NOT NULL,
+      "name" TEXT,
+      "email" TEXT NOT NULL UNIQUE,
+      "emailVerified" INTEGER,
+      "image" TEXT
+    )
+  `)
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS "bean" (
+      "id" TEXT PRIMARY KEY NOT NULL,
+      "user_id" TEXT REFERENCES "user"("id"),
+      "name" TEXT NOT NULL DEFAULT '',
+      "country" TEXT NOT NULL DEFAULT '',
+      "region" TEXT,
+      "farm" TEXT,
+      "process" TEXT,
+      "variety" TEXT,
+      "roast" TEXT NOT NULL DEFAULT '',
+      "roaster" TEXT,
+      "notes" TEXT,
+      "created" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updated" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+  `)
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS "brew" (
+      "id" TEXT PRIMARY KEY NOT NULL,
+      "user_id" TEXT REFERENCES "user"("id"),
+      "bean_id" TEXT NOT NULL DEFAULT '',
+      "bean_weight" REAL NOT NULL DEFAULT 0,
+      "bean_grind" REAL,
+      "water_weight" REAL NOT NULL DEFAULT 0,
+      "water_temp" REAL,
+      "steps" TEXT NOT NULL DEFAULT '[]',
+      "aroma" INTEGER NOT NULL DEFAULT 0,
+      "acidity" INTEGER NOT NULL DEFAULT 0,
+      "sweetness" INTEGER NOT NULL DEFAULT 0,
+      "body" INTEGER NOT NULL DEFAULT 0,
+      "overall" INTEGER NOT NULL DEFAULT 0,
+      "notes" TEXT,
+      "created" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updated" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+  `)
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS "brew_flavor" (
+      "id" TEXT PRIMARY KEY NOT NULL,
+      "brew_id" TEXT NOT NULL REFERENCES "brew"("id"),
+      "flavor_id" TEXT NOT NULL,
+      "created" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updated" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+  `)
+  // flavor テーブルも FlavorsRepository が参照するため作成
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS "flavor" (
+      "id" TEXT PRIMARY KEY NOT NULL,
+      "name" TEXT NOT NULL DEFAULT '',
+      "category" TEXT NOT NULL DEFAULT '',
+      "subcategory" TEXT NOT NULL DEFAULT '',
+      "created" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updated" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+  `)
+}
+
+// vi.hoisted で DB を作成し、vi.mock ファクトリで参照する
+// ':memory:' は drizzle transaction 時に別接続を開くため、テーブルが見えなくなる制約がある。
+// トランザクション後の DB 状態確認が必要なテストのため、一時ファイル DB を使用する。
+const { testDb } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { createClient: _createClient } = require('@libsql/client')
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { drizzle: _drizzle } = require('drizzle-orm/libsql')
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const _os = require('os')
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const _path = require('path')
+  const _dbPath = _path.join(_os.tmpdir(), `brews_repo_test_${Date.now()}.db`)
+  const _client = _createClient({ url: `file:${_dbPath}` })
+  const _db = _drizzle(_client)
+  return { testDb: { client: _client, db: _db, dbPath: _dbPath } }
+})
+
+vi.mock('@/lib/db/drizzle', () => ({
+  db: testDb.db,
+}))
+
+import { BrewsRepository } from '@/app/brews/repository'
+
+// テスト終了後に一時ファイルを削除する
+afterAll(() => {
+  try { unlinkSync(testDb.dbPath) } catch { /* ignore */ }
+  try { unlinkSync(testDb.dbPath + '-wal') } catch { /* ignore */ }
+  try { unlinkSync(testDb.dbPath + '-shm') } catch { /* ignore */ }
+})
+
+const validBrewInput = {
+  beanId: 'bean-A1',
+  beanWeight: 15,
+  beanGrind: 24,
+  waterWeight: 240,
+  waterTemp: 92,
+  steps: [],
+  aroma: 3,
+  acidity: 3,
+  sweetness: 3,
+  body: 3,
+  overall: 3,
+  notes: '',
+  flavorIds: [],
+}
+
+const updatedBrewInput = {
+  beanId: 'bean-A1',
+  beanWeight: 20,
+  beanGrind: 26,
+  waterWeight: 300,
+  waterTemp: 94,
+  steps: [],
+  aroma: 4,
+  acidity: 4,
+  sweetness: 4,
+  body: 4,
+  overall: 4,
+  notes: 'Updated',
+  flavorIds: [],
+}
+
+describe('BrewsRepository', () => {
+  let repository: BrewsRepository
+
+  beforeEach(async () => {
+    // スキーマをセットアップ
+    await setupSchema(testDb.client)
+
+    // テーブルをクリア（各テストの独立性を保つ）
+    await testDb.client.execute(`DELETE FROM brew_flavor`)
+    await testDb.client.execute(`DELETE FROM brew`)
+    await testDb.client.execute(`DELETE FROM bean`)
+
+    // テストデータを仕込む
+    // bean テーブル: user-A の bean 1件、user-B の bean 1件
+    await testDb.client.execute({
+      sql: `INSERT INTO bean (id, user_id, name, country, roast) VALUES (?, ?, ?, ?, ?)`,
+      args: ['bean-A1', 'user-A', 'Ethiopia Yirgacheffe', 'Ethiopia', 'Light'],
+    })
+    await testDb.client.execute({
+      sql: `INSERT INTO bean (id, user_id, name, country, roast) VALUES (?, ?, ?, ?, ?)`,
+      args: ['bean-B1', 'user-B', 'Colombia Huila', 'Colombia', 'City'],
+    })
+
+    // brew テーブル: user-A の brew 2件（bean-A1 に紐づく）、user-B の brew 1件（bean-B1 に紐づく）
+    await testDb.client.execute({
+      sql: `INSERT INTO brew (id, user_id, bean_id, bean_weight, water_weight, steps, aroma, acidity, sweetness, body, overall) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: ['brew-A1', 'user-A', 'bean-A1', 15, 240, '[]', 3, 3, 3, 3, 3],
+    })
+    await testDb.client.execute({
+      sql: `INSERT INTO brew (id, user_id, bean_id, bean_weight, water_weight, steps, aroma, acidity, sweetness, body, overall) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: ['brew-A2', 'user-A', 'bean-A1', 20, 300, '[]', 4, 4, 4, 4, 4],
+    })
+    await testDb.client.execute({
+      sql: `INSERT INTO brew (id, user_id, bean_id, bean_weight, water_weight, steps, aroma, acidity, sweetness, body, overall) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: ['brew-B1', 'user-B', 'bean-B1', 18, 270, '[]', 5, 5, 5, 5, 5],
+    })
+
+    repository = new BrewsRepository()
+  })
+
+  describe('findAll(userId)', () => {
+    it('BRW_FA1: userId="user-A" のとき user-A の brew のみ返す', async () => {
+      // Act
+      const brews = await repository.findAll('user-A')
+
+      // Assert
+      expect(brews.length).toBe(2)
+      expect(brews.find((b) => b.id === 'brew-B1')).toBeUndefined()
+    })
+
+    it('BRW_FA2: 該当ユーザーの brew が 0 件のとき空配列を返す', async () => {
+      // Act
+      const brews = await repository.findAll('user-C')
+
+      // Assert
+      expect(brews.length).toBe(0)
+    })
+  })
+
+  describe('findByBeanId(userId, beanId)', () => {
+    it('BRW_FB1: 自分の bean の beanId を渡したとき、その bean に紐づく自分の brew を返す', async () => {
+      // Act
+      const brews = await repository.findByBeanId('user-A', 'bean-A1')
+
+      // Assert
+      expect(brews.length).toBe(2)
+    })
+
+    it('BRW_FB2: 他ユーザーの bean の beanId を渡したとき空配列を返す（bean が見つからないため）', async () => {
+      // Act: user-A として user-B の bean を指定
+      const brews = await repository.findByBeanId('user-A', 'bean-B1')
+
+      // Assert: beansRepository.findById(userId, beanId) が undefined を返し、空配列になる
+      expect(brews.length).toBe(0)
+    })
+  })
+
+  describe('findById(userId, id)', () => {
+    it('BRW_FI1: 正しい userId + 存在する brew id のとき BrewWithBean を返す', async () => {
+      // Act
+      const brew = await repository.findById('user-A', 'brew-A1')
+
+      // Assert
+      expect(brew).toBeDefined()
+      expect(brew!.id).toBe('brew-A1')
+    })
+
+    it('BRW_FI2: 他ユーザーの brew id を渡したとき undefined を返す', async () => {
+      // Act
+      const brew = await repository.findById('user-A', 'brew-B1')
+
+      // Assert
+      expect(brew).toBeUndefined()
+    })
+  })
+
+  describe('findCountByBeanIdMap(userId)', () => {
+    it('BRW_FC1: userId="user-A" のとき user-A の bean に紐づく brew 数のみ集計する', async () => {
+      // Act
+      const map = await repository.findCountByBeanIdMap('user-A')
+
+      // Assert
+      expect(map.get('bean-A1')).toBe(2)
+      expect(map.has('bean-B1')).toBe(false)
+    })
+  })
+
+  describe('create(userId, input)', () => {
+    it('BRW_CR1: create を呼び出すと DB 行に userId が設定される', async () => {
+      // Act
+      const brew = await repository.create('user-A', validBrewInput)
+
+      // Assert: 返り値に userId が含まれる（@libsql/client の :memory: + drizzle transaction の
+      // 制約により、transaction commit 後の db.select では確認できないため、戻り値で確認する）
+      expect(brew.userId).toBe('user-A')
+      expect(brew.beanId).toBe(validBrewInput.beanId)
+    })
+  })
+
+  describe('update(userId, id, input)', () => {
+    it('BRW_UP1: 他ユーザーの brew id を指定したとき undefined を返す', async () => {
+      // Act
+      const brew = await repository.update('user-A', 'brew-B1', updatedBrewInput)
+
+      // Assert
+      expect(brew).toBeUndefined()
+    })
+  })
+
+  describe('delete(userId, id)', () => {
+    it('BRW_DE1: 他ユーザーの brew id を指定したとき false を返す（行が削除されない）', async () => {
+      // Act
+      const result = await repository.delete('user-A', 'brew-B1')
+
+      // Assert: false が返ることで「削除されなかった」ことを確認
+      // （@libsql/client の :memory: + drizzle transaction の制約により、
+      // transaction commit 後の db.select は別接続で行われるため
+      // transaction commit 後に db から行を確認することができない。
+      // false が返ることで userId フィルタが機能していることを確認する）
+      expect(result).toBe(false)
+    })
+
+    it('BRW_DE_CROSS_USER: user-B が user-A の brew を削除しようとしたとき、brew_flavor 行が残る', async () => {
+      // Arrange: user-A の brew-A1 に紐づく brew_flavor 行をシード
+      await testDb.client.execute({
+        sql: `INSERT INTO brew_flavor (id, brew_id, flavor_id) VALUES (?, ?, ?)`,
+        args: ['bf-A1', 'brew-A1', 'flavor-citrus'],
+      })
+
+      // Act: user-B として user-A の brew を削除しようとする
+      const result = await repository.delete('user-B', 'brew-A1')
+
+      // Assert 1: 戻り値が false（所有権なしなので削除失敗）
+      expect(result).toBe(false)
+
+      // Assert 2: user-A の brew 行が DB に残っている
+      const brewRows = await testDb.client.execute({
+        sql: `SELECT id FROM brew WHERE id = ?`,
+        args: ['brew-A1'],
+      })
+      expect(brewRows.rows.length).toBe(1)
+
+      // Assert 3: user-A の brew_flavor 行が DB に残っている（修正前は消えていた）
+      const flavorRows = await testDb.client.execute({
+        sql: `SELECT id FROM brew_flavor WHERE brew_id = ?`,
+        args: ['brew-A1'],
+      })
+      expect(flavorRows.rows.length).toBe(1)
+    })
+  })
+})

--- a/app/brews/repository.ts
+++ b/app/brews/repository.ts
@@ -1,6 +1,6 @@
 import 'server-only'
 
-import { count, desc, eq } from 'drizzle-orm'
+import { and, count, desc, eq } from 'drizzle-orm'
 import type { Brew, BrewStep, BrewWithBean } from '@/lib/types'
 import { db } from '@/lib/db/drizzle'
 import { brewFlavorsTable, brewsTable } from '@/lib/db/schema'
@@ -26,8 +26,22 @@ export interface BrewMutationInput {
 
 function mapBrewRow(row: typeof brewsTable.$inferSelect): Brew {
   return {
-    ...row,
+    id: row.id,
+    userId: row.userId ?? null,
+    beanId: row.beanId,
+    beanWeight: row.beanWeight,
+    beanGrind: row.beanGrind ?? null,
+    waterWeight: row.waterWeight,
+    waterTemp: row.waterTemp ?? null,
     steps: parseSteps(row.steps),
+    aroma: row.aroma,
+    acidity: row.acidity,
+    sweetness: row.sweetness,
+    body: row.body,
+    overall: row.overall,
+    notes: row.notes ?? null,
+    created: row.created,
+    updated: row.updated,
   }
 }
 
@@ -35,31 +49,33 @@ const beansRepository = new BeansRepository()
 const flavorsRepository = new FlavorsRepository()
 
 export class BrewsRepository {
-  async findAll(): Promise<Brew[]> {
+  async findAll(userId: string): Promise<Brew[]> {
     const rows = await db
       .select()
       .from(brewsTable)
+      .where(eq(brewsTable.userId, userId))
       .orderBy(desc(brewsTable.created))
 
     return rows.map(mapBrewRow)
   }
 
-  async findCountByBeanIdMap(): Promise<Map<string, number>> {
+  async findCountByBeanIdMap(userId: string): Promise<Map<string, number>> {
     const rows = await db
       .select({ beanId: brewsTable.beanId, brewCount: count(brewsTable.id) })
       .from(brewsTable)
+      .where(eq(brewsTable.userId, userId))
       .groupBy(brewsTable.beanId)
 
     return new Map(rows.map((row) => [row.beanId, row.brewCount]))
   }
 
-  async findByBeanId(beanId: string): Promise<BrewWithBean[]> {
+  async findByBeanId(userId: string, beanId: string): Promise<BrewWithBean[]> {
     const [bean, brewRows, flavorByBrewId] = await Promise.all([
-      beansRepository.findById(beanId),
+      beansRepository.findById(userId, beanId),
       db
         .select()
         .from(brewsTable)
-        .where(eq(brewsTable.beanId, beanId))
+        .where(and(eq(brewsTable.userId, userId), eq(brewsTable.beanId, beanId)))
         .orderBy(desc(brewsTable.created)),
       flavorsRepository.findMapByBeanId(beanId),
     ])
@@ -78,11 +94,11 @@ export class BrewsRepository {
     })
   }
 
-  async findById(id: string): Promise<BrewWithBean | undefined> {
+  async findById(userId: string, id: string): Promise<BrewWithBean | undefined> {
     const [brewRow] = await db
       .select()
       .from(brewsTable)
-      .where(eq(brewsTable.id, id))
+      .where(and(eq(brewsTable.userId, userId), eq(brewsTable.id, id)))
       .limit(1)
 
     if (!brewRow) {
@@ -91,7 +107,7 @@ export class BrewsRepository {
 
     const brew = mapBrewRow(brewRow)
     const [bean, flavors] = await Promise.all([
-      beansRepository.findById(brew.beanId),
+      beansRepository.findById(userId, brew.beanId),
       flavorsRepository.findByBrewId(id),
     ])
 
@@ -106,11 +122,12 @@ export class BrewsRepository {
     }
   }
 
-  async create(input: BrewMutationInput): Promise<Brew> {
+  async create(userId: string, input: BrewMutationInput): Promise<Brew> {
     return db.transaction(async (tx) => {
       const [brewRow] = await tx
         .insert(brewsTable)
         .values({
+          userId,
           beanId: input.beanId,
           beanWeight: input.beanWeight,
           beanGrind: input.beanGrind,
@@ -139,7 +156,7 @@ export class BrewsRepository {
     })
   }
 
-  async update(id: string, input: BrewMutationInput): Promise<Brew | undefined> {
+  async update(userId: string, id: string, input: BrewMutationInput): Promise<Brew | undefined> {
     return db.transaction(async (tx) => {
       const [brewRow] = await tx
         .update(brewsTable)
@@ -158,7 +175,7 @@ export class BrewsRepository {
           notes: input.notes,
           updated: new Date().toISOString(),
         })
-        .where(eq(brewsTable.id, id))
+        .where(and(eq(brewsTable.userId, userId), eq(brewsTable.id, id)))
         .returning()
 
       if (!brewRow) {
@@ -182,18 +199,22 @@ export class BrewsRepository {
     })
   }
 
-  async delete(id: string): Promise<boolean> {
+  async delete(userId: string, id: string): Promise<boolean> {
     return db.transaction(async (tx) => {
+      // 先に所有権確認を兼ねた brew 削除（userId フィルタで他ユーザーの brew は 0 件になる）
+      const result = await tx
+        .delete(brewsTable)
+        .where(and(eq(brewsTable.userId, userId), eq(brewsTable.id, id)))
+        .returning({ id: brewsTable.id })
+
+      if (result.length === 0) return false
+
+      // 所有権確認後に brew_flavor を削除
       await tx
         .delete(brewFlavorsTable)
         .where(eq(brewFlavorsTable.brewId, id))
 
-      const result = await tx
-        .delete(brewsTable)
-        .where(eq(brewsTable.id, id))
-        .returning({ id: brewsTable.id })
-
-      return result.length > 0
+      return true
     })
   }
 }

--- a/app/brews/service.ts
+++ b/app/brews/service.ts
@@ -6,24 +6,24 @@ import type { UpsertBrewDto } from '@/app/brews/schema'
 const brewsRepository = new BrewsRepository()
 
 export class BrewsService {
-  async getBrews() {
-    return brewsRepository.findAll()
+  async getBrews(userId: string) {
+    return brewsRepository.findAll(userId)
   }
 
-  async getBrewCountByBeanIdMap() {
-    return brewsRepository.findCountByBeanIdMap()
+  async getBrewCountByBeanIdMap(userId: string) {
+    return brewsRepository.findCountByBeanIdMap(userId)
   }
 
-  async getBrewsByBeanId(beanId: string) {
-    return brewsRepository.findByBeanId(beanId)
+  async getBrewsByBeanId(userId: string, beanId: string) {
+    return brewsRepository.findByBeanId(userId, beanId)
   }
 
-  async getBrewById(id: string) {
-    return brewsRepository.findById(id)
+  async getBrewById(userId: string, id: string) {
+    return brewsRepository.findById(userId, id)
   }
 
-  async createBrew(dto: UpsertBrewDto) {
-    return brewsRepository.create({
+  async createBrew(userId: string, dto: UpsertBrewDto) {
+    return brewsRepository.create(userId, {
       beanId: dto.beanId,
       beanWeight: dto.beanWeight,
       beanGrind: dto.beanGrind,
@@ -40,8 +40,8 @@ export class BrewsService {
     })
   }
 
-  async updateBrew(id: string, dto: UpsertBrewDto) {
-    return brewsRepository.update(id, {
+  async updateBrew(userId: string, id: string, dto: UpsertBrewDto) {
+    return brewsRepository.update(userId, id, {
       beanId: dto.beanId,
       beanWeight: dto.beanWeight,
       beanGrind: dto.beanGrind,
@@ -58,8 +58,8 @@ export class BrewsService {
     })
   }
 
-  async deleteBrew(id: string) {
-    return brewsRepository.delete(id)
+  async deleteBrew(userId: string, id: string) {
+    return brewsRepository.delete(userId, id)
   }
 }
 

--- a/app/login/page.render.test.tsx
+++ b/app/login/page.render.test.tsx
@@ -1,0 +1,63 @@
+// jsdom 環境（デフォルト）
+
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { authMock, redirectMock, signInMock } = vi.hoisted(() => ({
+  authMock: vi.fn(),
+  redirectMock: vi.fn(),
+  signInMock: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  auth: authMock,
+  signIn: signInMock,
+}))
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}))
+
+// next/font/google はレイアウトと同様にモックする
+vi.mock('next/font/google', () => ({
+  DM_Sans: () => ({ className: 'dm-sans', variable: '--font-sans' }),
+  DM_Mono: () => ({ className: 'dm-mono', variable: '--font-mono' }),
+}))
+
+import LoginPage from '@/app/login/page'
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('LP1: 未認証状態でレンダリングしたとき Google ログインボタンが存在する', async () => {
+    authMock.mockResolvedValue(null)
+
+    render(await LoginPage())
+
+    expect(
+      screen.getByRole('button', { name: /google/i }) ||
+      screen.getByText(/google/i)
+    ).toBeTruthy()
+  })
+
+  it('LP2: 未認証状態でレンダリングしたとき Email 入力フィールドが存在する', async () => {
+    authMock.mockResolvedValue(null)
+
+    render(await LoginPage())
+
+    expect(
+      screen.getByRole('textbox') ||
+      screen.getByPlaceholderText(/email/i)
+    ).toBeTruthy()
+  })
+
+  it('LP3: 認証済み状態でレンダリングしたとき redirect("/") が呼ばれる', async () => {
+    authMock.mockResolvedValue({ user: { id: 'user-1', email: 'a@example.com' } })
+
+    await LoginPage()
+
+    expect(redirectMock).toHaveBeenCalledWith('/')
+  })
+})

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,104 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+import { auth, signIn } from '@/lib/auth'
+
+export default async function LoginPage() {
+  const session = await auth()
+
+  if (session?.user?.id) {
+    redirect('/')
+    return null
+  }
+
+  async function handleGoogleSignIn() {
+    'use server'
+    await signIn('google')
+  }
+
+  async function handleEmailSignIn(formData: FormData) {
+    'use server'
+    const email = formData.get('email') as string
+    await signIn('resend', { email, redirectTo: '/' })
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+      <div className="w-full max-w-sm space-y-8">
+        {/* Header */}
+        <div className="text-center">
+          <h1 className="text-2xl font-semibold tracking-tight text-foreground">Brewia</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Sign in to track your coffee journey
+          </p>
+        </div>
+
+        {/* Google Sign In */}
+        <form action={handleGoogleSignIn}>
+          <button
+            type="submit"
+            className="flex w-full items-center justify-center gap-3 rounded-lg border border-border bg-background px-4 py-2.5 text-sm font-medium text-foreground shadow-sm hover:bg-muted"
+          >
+            <svg
+              className="h-5 w-5"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                fill="#4285F4"
+              />
+              <path
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                fill="#34A853"
+              />
+              <path
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                fill="#FBBC05"
+              />
+              <path
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                fill="#EA4335"
+              />
+            </svg>
+            Sign in with Google
+          </button>
+        </form>
+
+        {/* Divider */}
+        <div className="relative">
+          <div className="absolute inset-0 flex items-center">
+            <span className="w-full border-t border-border" />
+          </div>
+          <div className="relative flex justify-center text-xs uppercase">
+            <span className="bg-background px-2 text-muted-foreground">Or continue with email</span>
+          </div>
+        </div>
+
+        {/* Email Magic Link */}
+        <form action={handleEmailSignIn} className="space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="email" className="text-sm font-medium text-foreground">
+              Email address
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              required
+              placeholder="you@example.com"
+              className="flex h-10 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </div>
+          <button
+            type="submit"
+            className="flex w-full items-center justify-center rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            Send magic link
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/app/new/page.tsx
+++ b/app/new/page.tsx
@@ -5,6 +5,7 @@ import { NewEntryTabs } from '@/components/new-entry-tabs'
 import { beansService } from '@/app/beans/service'
 import { flavorsService } from '@/app/flavors/service'
 import { brewsService } from '@/app/brews/service'
+import { requireUser } from '@/lib/auth/require-user'
 
 export const dynamic = 'force-dynamic'
 
@@ -18,12 +19,14 @@ interface NewPageProps {
 }
 
 export default async function NewPage({ searchParams }: NewPageProps) {
+  const user = await requireUser()
   const params = await searchParams
+
   const [beans, flavors, initialBean, initialBrew] = await Promise.all([
-    beansService.getBeans(),
+    beansService.getBeans(user.id),
     flavorsService.getFlavors(),
-    params.copyBean ? beansService.getBeanById(params.copyBean) : Promise.resolve(undefined),
-    params.copyBrew ? brewsService.getBrewById(params.copyBrew) : Promise.resolve(undefined),
+    params.copyBean ? beansService.getBeanById(user.id, params.copyBean) : Promise.resolve(undefined),
+    params.copyBrew ? brewsService.getBrewById(user.id, params.copyBrew) : Promise.resolve(undefined),
   ])
 
   return (

--- a/app/page.render.test.tsx
+++ b/app/page.render.test.tsx
@@ -1,0 +1,124 @@
+// jsdom 環境（デフォルト）
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// next/font/google は Vitest + jsdom 環境では動作しないためモックする
+vi.mock('next/font/google', () => ({
+  DM_Sans: () => ({ className: 'dm-sans', variable: '--font-sans' }),
+  DM_Mono: () => ({ className: 'dm-mono', variable: '--font-mono' }),
+}))
+
+// globals.css は Vitest 環境では不要なためモックする
+vi.mock('./globals.css', () => ({}))
+
+const { requireUserMock, getBeansMock, getBrewsMock } = vi.hoisted(() => ({
+  requireUserMock: vi.fn(),
+  getBeansMock: vi.fn(),
+  getBrewsMock: vi.fn(),
+}))
+
+vi.mock('@/lib/auth/require-user', () => ({
+  requireUser: requireUserMock,
+}))
+
+vi.mock('@/app/beans/service', () => ({
+  beansService: {
+    getBeans: getBeansMock,
+  },
+}))
+
+vi.mock('@/app/brews/service', () => ({
+  brewsService: {
+    getBrews: getBrewsMock,
+  },
+}))
+
+// lucide-react をモック（Server Component のレンダリングを単純化）
+vi.mock('lucide-react', () => ({
+  Plus: () => null,
+  Coffee: () => null,
+  Flame: () => null,
+}))
+
+// next/link をモック
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode
+    href: string
+  }) => <a href={href}>{children}</a>,
+}))
+
+// UI コンポーネントをモック
+vi.mock('@/components/stats-card', () => ({
+  StatsCard: () => <div data-testid="stats-card" />,
+}))
+
+vi.mock('@/components/bean-card', () => ({
+  BeanCard: () => <div data-testid="bean-card" />,
+}))
+
+vi.mock('@/components/greeting', () => ({
+  Greeting: () => <div data-testid="greeting" />,
+}))
+
+vi.mock('@/components/ui/empty', () => ({
+  Empty: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  EmptyContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  EmptyDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  EmptyHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  EmptyMedia: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  EmptyTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+import HomePage from '@/app/page'
+
+describe('HomePage (Server Component)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getBeansMock.mockResolvedValue([])
+    getBrewsMock.mockResolvedValue([])
+  })
+
+  it('HP1: requireUser が呼ばれる', async () => {
+    requireUserMock.mockResolvedValue({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
+
+    await HomePage()
+
+    expect(requireUserMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('HP2: 未認証のとき requireUser が redirect を発動し、ページ本体がレンダリングされない', async () => {
+    requireUserMock.mockImplementation(() => {
+      throw new Error('NEXT_REDIRECT')
+    })
+
+    try {
+      await HomePage()
+    } catch {
+      // redirect() が throw するため catch する
+    }
+
+    expect(getBeansMock).not.toHaveBeenCalled()
+  })
+
+  it('HP3: 認証済みのとき beansService.getBeans(userId) が正しい userId で呼ばれる', async () => {
+    requireUserMock.mockResolvedValue({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Alice',
+    })
+    getBeansMock.mockResolvedValue([])
+    getBrewsMock.mockResolvedValue([])
+
+    await HomePage()
+
+    expect(getBeansMock).toHaveBeenCalledWith('user-1')
+  })
+})

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import { beansService } from '@/app/beans/service'
 import { brewsService } from '@/app/brews/service'
+import { requireUser } from '@/lib/auth/require-user'
 import { StatsCard } from '@/components/stats-card'
 import { BeanCard } from '@/components/bean-card'
 import { Greeting } from '@/components/greeting'
@@ -17,9 +18,11 @@ import Link from 'next/link'
 export const dynamic = 'force-dynamic'
 
 export default async function HomePage() {
+  const user = await requireUser()
+
   const [beans, brews] = await Promise.all([
-    beansService.getBeans(),
-    brewsService.getBrews(),
+    beansService.getBeans(user.id),
+    brewsService.getBrews(user.id),
   ])
 
   // Calculate stats

--- a/components/brew-card.test.tsx
+++ b/components/brew-card.test.tsx
@@ -33,6 +33,7 @@ const baseBrew: BrewWithBean = {
     roast: 'Light',
     roaster: 'Glitch',
     updated: '2026-04-18T00:00:00.000Z',
+    userId: null,
     variety: 'SL28',
   },
   beanGrind: 24,
@@ -47,6 +48,7 @@ const baseBrew: BrewWithBean = {
   steps: [],
   sweetness: 4,
   updated: '2026-04-18T00:00:00.000Z',
+  userId: null,
   waterTemp: 92,
   waterWeight: 225,
 }

--- a/components/new-bean-form.test.tsx
+++ b/components/new-bean-form.test.tsx
@@ -312,7 +312,7 @@ describe('NewBeanForm', () => {
     const bean = {
       id: 'b1', name: 'Test', country: 'Ethiopia' as const, region: null, farm: null,
       process: null, variety: null, roast: 'Medium' as const, roaster: 'R',
-      notes: null, created: '', updated: '',
+      notes: null, created: '', updated: '', userId: null,
     }
     render(<NewBeanForm mode="edit" initialBean={bean} />)
     expect(screen.getByTestId('mock-photo-picker')).toBeDefined()
@@ -458,6 +458,7 @@ describe('NewBeanForm', () => {
       notes: null,
       created: '2026-04-18T00:00:00.000Z',
       updated: '2026-04-18T00:00:00.000Z',
+      userId: null,
     }
     render(<NewBeanForm mode="edit" initialBean={initialBean} />)
 

--- a/components/new-brew-form.test.tsx
+++ b/components/new-brew-form.test.tsx
@@ -172,6 +172,7 @@ const beans: Bean[] = [
     roast: 'Light',
     roaster: 'Glitch',
     updated: '2026-04-18T00:00:00.000Z',
+    userId: null,
     variety: 'SL28',
   },
 ]
@@ -441,6 +442,7 @@ describe('NewBrewForm', () => {
         roast: 'Light',
         roaster: 'Glitch',
         updated: '2026-04-18T00:00:00.000Z',
+        userId: null,
         variety: 'SL28',
       },
       beanGrind: 24,
@@ -455,6 +457,7 @@ describe('NewBrewForm', () => {
       steps: [],
       sweetness: 0,
       updated: '2026-04-18T00:00:00.000Z',
+      userId: null,
       waterTemp: 92,
       waterWeight: 225,
     }
@@ -485,6 +488,7 @@ describe('NewBrewForm', () => {
         roast: 'Light',
         roaster: 'Glitch',
         updated: '2026-04-18T00:00:00.000Z',
+        userId: null,
         variety: 'SL28',
       },
       beanGrind: 24,
@@ -499,6 +503,7 @@ describe('NewBrewForm', () => {
       steps: [],
       sweetness: 4,
       updated: '2026-04-18T00:00:00.000Z',
+      userId: null,
       waterTemp: 92,
       waterWeight: 225,
     }
@@ -537,6 +542,7 @@ describe('NewBrewForm', () => {
         roast: 'Light',
         roaster: 'Glitch',
         updated: '2026-04-18T00:00:00.000Z',
+        userId: null,
         variety: 'SL28',
       },
       beanGrind: 24,
@@ -551,6 +557,7 @@ describe('NewBrewForm', () => {
       steps: [{ time: 120, water: 225 }],
       sweetness: 0,
       updated: '2026-04-18T00:00:00.000Z',
+      userId: null,
       waterTemp: 92,
       waterWeight: 225,
     }

--- a/docs/auth-architecture.md
+++ b/docs/auth-architecture.md
@@ -1,0 +1,778 @@
+# Auth Architecture — Issue #82
+
+ユーザー認証とユーザーごとのデータ管理の実装設計ドキュメント。
+
+---
+
+## 1. Goal と Non-goal
+
+### Goals
+
+- Auth.js (NextAuth v5 beta) + Google OAuth + Email Magic Link によるログイン/ログアウト
+- ユーザーセッションを Turso（libSQL/SQLite）に永続化
+- `bean` / `brew` をユーザー単位にスコープし、他ユーザーのデータに一切アクセスできないよう保護
+- 既存データの喪失なし（最初のログインユーザーが既存データを引き取る backfill）
+- `/login` と `/api/auth/*` 以外の全ルートでログイン必須
+
+### Non-goals（後続課題）
+
+- ユーザー間のデータシェア機能
+- チーム/組織単位のテナンシー
+- ロール（admin 等）
+- プロフィール編集画面（最小表示のみ将来スコープ）
+- パスワード認証
+- 複数アカウントの統合/マージ
+
+---
+
+## 2. 合意済みの方針（再掲）
+
+1. **認証プロバイダ**: Auth.js (NextAuth v5 beta / `next-auth@5`) + Drizzle Adapter (`@auth/drizzle-adapter`)。user/account/session/verificationToken テーブルを Turso に相乗り。
+2. **ログイン手段**: Google OAuth + Email Magic Link（実装時は Resend を想定、インターフェースは抽象化）。
+3. **既存データ移行**: 最初にログインしたユーザーが既存の全 bean/brew/brew_flavor を引き取る backfill SQL。データ喪失は避ける。
+4. **`flavor` は共有マスタ**: `user_id` を付けない。全ユーザーで共有。
+5. **未認証ゲート**: `/login` と `/api/auth/*` 以外はすべてログイン必須。未認証は `/login` にリダイレクト。
+
+---
+
+## 3. 最終的な DB スキーマ
+
+### 3.1 Mermaid ERD
+
+```mermaid
+erDiagram
+    user {
+        text id PK
+        text name
+        text email UK
+        text emailVerified
+        text image
+    }
+    account {
+        text userId FK
+        text type
+        text provider
+        text providerAccountId
+        text refresh_token
+        text access_token
+        integer expires_at
+        text token_type
+        text scope
+        text id_token
+        text session_state
+    }
+    session {
+        text sessionToken PK
+        text userId FK
+        text expires
+    }
+    verificationToken {
+        text identifier
+        text token
+        text expires
+    }
+    bean {
+        text id PK
+        text user_id FK
+        text name
+        text country
+        text region
+        text farm
+        text process
+        text variety
+        text roast
+        text roaster
+        text notes
+        text created
+        text updated
+    }
+    brew {
+        text id PK
+        text user_id FK
+        text bean_id FK
+        real bean_weight
+        real bean_grind
+        real water_weight
+        real water_temp
+        text steps
+        integer aroma
+        integer acidity
+        integer sweetness
+        integer body
+        integer overall
+        text notes
+        text created
+        text updated
+    }
+    brew_flavor {
+        text id PK
+        text brew_id FK
+        text flavor_id FK
+        text created
+        text updated
+    }
+    flavor {
+        text id PK
+        text name
+        text category
+        text subcategory
+        text created
+        text updated
+    }
+
+    user ||--o{ account : "has"
+    user ||--o{ session : "has"
+    user ||--o{ bean : "owns"
+    user ||--o{ brew : "owns"
+    bean ||--o{ brew : "has"
+    brew ||--o{ brew_flavor : "has"
+    flavor ||--o{ brew_flavor : "tagged in"
+```
+
+### 3.2 `brew_flavor` に `user_id` を付けない根拠
+
+`brew_flavor` は `brew_id` を外部キーとして持ち、`brew` には `user_id` がある。
+アクセス制御は常に「brew が当該ユーザーのものか」で決まるため、`brew_flavor` に独立した `user_id` を持たせることは冗長であり、整合性上のリスク（brew と brew_flavor の user_id が不一致になるバグ）を生む。
+クエリ上も `brew_flavor JOIN brew WHERE brew.user_id = ?` で完結する。
+
+### 3.3 Drizzle スキーマ擬似コード（`lib/db/schema.ts` 追記分）
+
+```typescript
+// --- Auth.js テーブル群（@auth/drizzle-adapter sqlite 最新仕様準拠）---
+
+export const usersTable = sqliteTable('user', {
+  id: text('id').notNull().primaryKey(),
+  name: text('name'),
+  email: text('email').notNull().unique(),
+  emailVerified: integer('emailVerified', { mode: 'timestamp_ms' }),
+  image: text('image'),
+})
+
+export const accountsTable = sqliteTable(
+  'account',
+  {
+    userId: text('userId')
+      .notNull()
+      .references(() => usersTable.id, { onDelete: 'cascade' }),
+    type: text('type').notNull(),
+    provider: text('provider').notNull(),
+    providerAccountId: text('providerAccountId').notNull(),
+    refresh_token: text('refresh_token'),
+    access_token: text('access_token'),
+    expires_at: integer('expires_at'),
+    token_type: text('token_type'),
+    scope: text('scope'),
+    id_token: text('id_token'),
+    session_state: text('session_state'),
+  },
+  (t) => ({ pk: primaryKey({ columns: [t.provider, t.providerAccountId] }) })
+)
+
+export const sessionsTable = sqliteTable('session', {
+  sessionToken: text('sessionToken').notNull().primaryKey(),
+  userId: text('userId')
+    .notNull()
+    .references(() => usersTable.id, { onDelete: 'cascade' }),
+  expires: integer('expires', { mode: 'timestamp_ms' }).notNull(),
+})
+
+export const verificationTokensTable = sqliteTable(
+  'verificationToken',
+  {
+    identifier: text('identifier').notNull(),
+    token: text('token').notNull(),
+    expires: integer('expires', { mode: 'timestamp_ms' }).notNull(),
+  },
+  (t) => ({ pk: primaryKey({ columns: [t.identifier, t.token] }) })
+)
+
+// --- 既存テーブルへの user_id 追加（Step 1: nullable）---
+
+export const beansTable = sqliteTable('bean', {
+  id: text('id').primaryKey().$defaultFn(() => uuidv7()),
+  userId: text('user_id').references(() => usersTable.id),  // nullable → Step 6 で notNull() 化
+  // ...existing columns
+})
+
+export const brewsTable = sqliteTable('brew', {
+  id: text('id').primaryKey().$defaultFn(() => uuidv7()),
+  userId: text('user_id').references(() => usersTable.id),  // nullable → Step 6 で notNull() 化
+  // ...existing columns
+})
+```
+
+---
+
+## 4. レイヤ責務とテナント境界の強制方法
+
+### 4.1 責務マップ
+
+```
+middleware.ts
+  └─ 未認証リクエストを /login にリダイレクト（ページナビ + API 両方）
+
+Route Handler (app/api/**/route.ts)
+  └─ requireUser() でセッションを取得し userId を Service に渡す
+  └─ 認証エラー → 401
+
+Service (app/**/service.ts)
+  └─ userId を受け取り、Repository に渡す
+  └─ ビジネスロジック。userId を自分で生成・推測しない
+
+Repository (app/**/repository.ts)
+  └─ userId を必須引数にする（型で強制）
+  └─ 全クエリに WHERE user_id = userId を適用
+  └─ 他人の行が返ることを構造的に不可能にする
+```
+
+### 4.2 `requireUser()` ヘルパ
+
+**配置**: `lib/auth/require-user.ts`
+
+```typescript
+// 概念コード
+import { auth } from '@/lib/auth/config'
+import { redirect } from 'next/navigation'
+
+export interface AuthenticatedUser {
+  id: string
+  email: string
+  name: string | null
+}
+
+// Server Component / Server Action 用（redirect を内包）
+export async function requireUser(): Promise<AuthenticatedUser> {
+  const session = await auth()
+  if (!session?.user?.id) {
+    redirect('/login')
+  }
+  return {
+    id: session.user.id,
+    email: session.user.email!,
+    name: session.user.name ?? null,
+  }
+}
+
+// Route Handler 用（redirect ではなく null を返す）
+export async function getAuthenticatedUser(): Promise<AuthenticatedUser | null> {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return null
+  }
+  return {
+    id: session.user.id,
+    email: session.user.email!,
+    name: session.user.name ?? null,
+  }
+}
+```
+
+- `requireUser()` は Server Component / Server Action で使う。未認証時は `redirect('/login')` を発行。
+- `getAuthenticatedUser()` は Route Handler で使う。未認証時は `null` を返し、呼び出し元が `401` を返す。
+- middleware がほとんどのリクエストを事前にブロックするため、二重チェックではあるが、深層防護として両方を維持する。
+
+### 4.3 Repository 層の型強制
+
+**方針**: Repository のすべての public メソッドが `userId: string` を必須引数として受け取る。
+
+```typescript
+// BeansRepository の変更後シグネチャ例
+export class BeansRepository {
+  async findAll(userId: string): Promise<Bean[]>
+  async findById(userId: string, id: string): Promise<Bean | undefined>
+  async create(userId: string, input: BeanMutationInput): Promise<Bean>
+  async update(userId: string, id: string, input: BeanMutationInput): Promise<Bean | undefined>
+  async delete(userId: string, id: string): Promise<boolean>
+}
+```
+
+TypeScript の型システムによって `userId` の渡し忘れはコンパイルエラーになる。
+Drizzle クエリの内部では常に `.where(and(eq(beansTable.userId, userId), eq(beansTable.id, id)))` を使う。
+
+### 4.4 Service 層のシグネチャ方針
+
+Service メソッドも同様に `userId: string` を必須引数として受け取る（ファクトリパターンは採用しない）。
+
+**採用理由**:
+- 現行コードは `new BeansService()` を module スコープでインスタンス化するシングルトン（`export const beansService = new BeansService()`）。このパターンを維持できる。
+- ファクトリ（`BeansRepository.forUser(userId)`）は DI が増えた場合に有効だが、現状の規模では過剰。
+- userId をメソッド引数として流すほうが、呼び出しスタック上でいつでも可視化でき、テストでモックしやすい。
+
+```typescript
+// BeansService の変更後シグネチャ例
+export class BeansService {
+  async getBeans(userId: string): Promise<Bean[]>
+  async getBeanById(userId: string, id: string): Promise<Bean | undefined>
+  async createBean(userId: string, dto: UpsertBeanDto): Promise<Bean>
+  async updateBean(userId: string, id: string, dto: UpsertBeanDto): Promise<Bean | undefined>
+  async deleteBean(userId: string, id: string): Promise<boolean>
+}
+```
+
+---
+
+## 5. 認可ポリシーマトリクス
+
+| レイヤ | 対象 | 正常系 | 未認証 | 他人のリソース |
+|---|---|---|---|---|
+| middleware | 全ルート（`/login`, `/api/auth/*` 除く） | 通過 | `/login` リダイレクト | — |
+| Route Handler | `GET /api/beans` | 200 + 自分のデータのみ | 401 | — |
+| Route Handler | `GET /api/beans/[id]` | 200 | 401 | 404（存在しないと同じ） |
+| Route Handler | `POST /api/beans` | 201 | 401 | — |
+| Route Handler | `PUT /api/beans/[id]` | 200 | 401 | 404 |
+| Route Handler | `DELETE /api/beans/[id]` | 204 | 401 | 404 |
+| Route Handler | `GET /api/brews` | 200 + 自分のデータのみ | 401 | — |
+| Route Handler | `POST/PUT/DELETE /api/brews/[id]` | 200/204 | 401 | 404 |
+| Route Handler | `POST /api/beans/extract` | 200 | 401 | — |
+| Route Handler | `GET /api/flavors` | 200（全ユーザー共通） | 401 | — |
+| Server Component | `app/page.tsx` など全ページ | 表示 | `/login` リダイレクト | — |
+| Repository | 全メソッド | `WHERE user_id = ?` で絞り込み | 呼ばれない | クエリが 0 件を返す |
+
+**404 を返す根拠**: 403 はリソースの存在を漏らす。404 はセキュリティ上より安全であり、「そのリソースが自分には見えない」という意味で一貫している。
+
+### `/api/beans/extract` の認証要否
+
+認証必須。LLM API コールはコスト発生を伴うため、未認証からのアクセスを許可しない。middleware がブロックするが、Route Handler でも `getAuthenticatedUser()` チェックを追加する。
+
+### PWA オフライン時の挙動
+
+- **ログイン済み → オフライン**: Service Worker の Network First 戦略により、ナビゲーションは `/offline` にフォールバック。API リクエストはキャッシュなし（`/api/` はスルー）なのでエラーになる。ユーザーはオフラインページを見る。セッション情報はブラウザの Cookie に残るため、オンラインに戻れば即座に復帰できる。
+- **未ログイン → アプリアクセス**: middleware がリダイレクトする前にオフラインになった場合、`/offline` ページが表示される。ログインページ自体はプリキャッシュ対象外なのでオフラインでは表示できない。これは許容範囲内（ログインにはネットワークが必須）。
+- **ログアウト時のキャッシュ**: `/api/` はキャッシュされないため、ログアウト後にキャッシュからデータが漏れるリスクはない。`/_next/static/` の静的アセットはユーザー固有の内容を含まないため問題なし。
+
+---
+
+## 6. ファイル構成の差分
+
+### 新規追加ファイル
+
+```
+lib/
+  auth/
+    config.ts          # NextAuth({ providers, adapter, callbacks, ... }) の設定
+    require-user.ts    # requireUser() / getAuthenticatedUser() ヘルパ
+    index.ts           # config.ts から { auth, handlers, signIn, signOut } を re-export
+
+app/
+  api/
+    auth/
+      [...nextauth]/
+        route.ts       # GET/POST を handlers にバインド
+
+  login/
+    page.tsx           # ログインページ（サインインボタン, プロバイダ選択 UI）
+
+middleware.ts          # App Router の Edge middleware
+```
+
+### 変更ファイル
+
+```
+lib/db/schema.ts
+  + usersTable, accountsTable, sessionsTable, verificationTokensTable
+  + beansTable.userId (nullable text, FK→user.id)
+  + brewsTable.userId (nullable text, FK→user.id)
+
+app/beans/repository.ts
+  - findAll()                        + findAll(userId: string)
+  - findById(id)                     + findById(userId, id)
+  - create(input)                    + create(userId, input)
+  - update(id, input)                + update(userId, id, input)
+  - delete(id)                       + delete(userId, id)
+  全クエリに AND bean.user_id = userId 追加
+
+app/brews/repository.ts
+  - findAll()                        + findAll(userId: string)
+  - findCountByBeanIdMap()           + findCountByBeanIdMap(userId)
+  - findByBeanId(beanId)             + findByBeanId(userId, beanId)
+  - findById(id)                     + findById(userId, id)
+  - create(input)                    + create(userId, input)（userId を INSERT に含める）
+  - update(id, input)                + update(userId, id, input)
+  - delete(id)                       + delete(userId, id)
+  全クエリに AND brew.user_id = userId 追加
+
+app/beans/service.ts
+  全メソッドに userId: string 引数追加
+
+app/brews/service.ts
+  全メソッドに userId: string 引数追加
+
+app/api/beans/route.ts
+app/api/beans/[id]/route.ts
+app/api/brews/route.ts
+app/api/brews/[id]/route.ts
+app/api/beans/extract/route.ts
+app/api/flavors/route.ts
+  全 handler に getAuthenticatedUser() 追加 → 401 or userId を service に渡す
+
+app/page.tsx
+app/beans/[id]/page.tsx
+app/beans/[id]/edit/page.tsx
+app/brews/[id]/page.tsx
+app/brews/[id]/edit/page.tsx
+app/new/page.tsx
+  requireUser() を追加し userId を service に渡す
+
+app/layout.tsx
+  セッションプロバイダ不要（Auth.js v5 は RSC ネイティブ）
+
+.env.example
+  AUTH_SECRET, AUTH_GOOGLE_ID, AUTH_GOOGLE_SECRET, AUTH_RESEND_KEY, EMAIL_FROM 追加
+
+drizzle/
+  0001_add_auth_tables.sql        # Auth.js 4テーブル追加
+  0002_add_user_id_nullable.sql   # bean/brew に user_id nullable 追加
+  0003_backfill_user_id.sql       # backfill (MANUAL / アプリ初回サインイン時に実行)
+  (0004_user_id_not_null.sql)     # 将来: NOT NULL 化（スライス 6）
+```
+
+### `middleware.ts` の設計
+
+```typescript
+// 配置: /Users/yuji/Documents/GitHub/brewia-issue-82/middleware.ts
+import { auth } from '@/lib/auth'
+import type { NextRequest } from 'next/server'
+
+export default auth((req: NextRequest & { auth: unknown }) => {
+  const isLoggedIn = !!req.auth
+  const isAuthRoute = req.nextUrl.pathname.startsWith('/api/auth')
+  const isLoginPage = req.nextUrl.pathname === '/login'
+  const isOfflinePage = req.nextUrl.pathname === '/offline'
+
+  if (isAuthRoute || isLoginPage || isOfflinePage) {
+    return // 通過
+  }
+
+  if (!isLoggedIn) {
+    const loginUrl = new URL('/login', req.url)
+    return Response.redirect(loginUrl)
+  }
+})
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|icon|manifest|sw\\.js|favicon).*)'],
+}
+```
+
+**matcher の設計意図**:
+- `_next/static`, `_next/image`: Next.js 内部アセット。middleware を通す必要なし。
+- `icon`, `manifest`, `sw.js`, `favicon`: PWA・ブラウザ向け静的ファイル。ログイン不要。
+- それ以外（ページ・API 含む）はすべて middleware を通す。
+
+### `app/login/page.tsx` の責務
+
+- Server Component。`requireUser()` は呼ばない（ログインページ自体は公開）。
+- セッションがある場合は `/` にリダイレクト（`auth()` を呼んで確認）。
+- Google ログインボタンと Email Magic Link フォームを表示。
+- `signIn('google')` / `signIn('resend', { email })` を Server Action または Client Component から呼び出す。
+
+---
+
+## 7. マイグレーション戦略
+
+Drizzle migration は `drizzle/` ディレクトリに連番 SQL ファイルとして出力される。以下の段階で実施する。
+
+### マイグレーション 0001 — Auth.js テーブル追加
+
+**ファイル**: `drizzle/0001_add_auth_tables.sql`（`pnpm db:generate` で生成）
+
+内容:
+- `user` テーブル作成
+- `account` テーブル作成（FK: user.id CASCADE DELETE）
+- `session` テーブル作成（FK: user.id CASCADE DELETE）
+- `verificationToken` テーブル作成
+
+実施タイミング: スライス 1 完了時点で本番 DB に適用。
+ロールバック: これらのテーブルを DROP する逆 SQL（データなし期間なので安全）。
+
+### マイグレーション 0002 — bean/brew に user_id 列追加（nullable）
+
+**ファイル**: `drizzle/0002_add_user_id_nullable.sql`
+
+```sql
+ALTER TABLE bean ADD COLUMN user_id TEXT REFERENCES user(id);
+ALTER TABLE brew ADD COLUMN user_id TEXT REFERENCES user(id);
+```
+
+実施タイミング: スライス 2 完了時点で本番 DB に適用。
+注意: この時点では既存行の `user_id` は NULL。アプリはまだ全データを返す（スライス 3 で境界を引く前）。
+
+### マイグレーション 0003 — backfill（最初のユーザーへの全データ割り当て）
+
+**ファイル**: `drizzle/0003_backfill_user_id.sql`（手動実行 SQL）
+
+```sql
+-- 最初にサインインしたユーザーのIDをここに差し替えて実行すること
+-- 運用手順: 本番で1人目がサインインした直後に管理者が手動で発行する
+
+UPDATE bean SET user_id = '<FIRST_USER_ID>' WHERE user_id IS NULL;
+UPDATE brew SET user_id = '<FIRST_USER_ID>' WHERE user_id IS NULL;
+```
+
+**代替案（アプリ内自動 backfill）**: 初回サインイン時の Auth.js `signIn` callback で、`user_id IS NULL` な行を検出して自動的にそのユーザーに割り当てるロジックをアプリコードとして実装する。この場合、本 SQL は実行不要になる。
+
+推奨: アプリ内自動 backfill。理由は手動実行ミスのリスク排除と、デプロイフローへの組み込みやすさ。具体的には Auth.js の `signIn` callback 内で `db.update(beansTable).set({ userId: user.id }).where(isNull(beansTable.userId))` を実行する。
+
+実施タイミング: スライス 2 または 3 で対応。本番への最初のユーザーログイン前に準備を完了させる。
+
+### マイグレーション 0004 — NOT NULL 化（将来）
+
+**ファイル**: `drizzle/0004_user_id_not_null.sql`（スライス 6）
+
+SQLite は `ALTER COLUMN` をサポートしないため、テーブル再作成が必要。
+
+手順:
+1. `bean_new` / `brew_new` テーブルを `user_id NOT NULL` 制約付きで作成
+2. `INSERT INTO bean_new SELECT * FROM bean` を実行（NULL 行が残っていたらエラーになる = 安全チェック）
+3. `DROP TABLE bean` → `ALTER TABLE bean_new RENAME TO bean`
+4. インデックス・FK を再作成
+
+実施タイミング: backfill が完了し、全行に user_id が設定されたことを確認してから。
+
+---
+
+## 8. フェーズ分割（TDD スライス案）
+
+### スライス 1: Auth.js 基盤
+
+**目的**: Google OAuth + Email Magic Link でのログイン/ログアウトが動作する。セッションが Turso に保存される。
+
+**対象ファイル**:
+- `package.json` に `next-auth@5`, `@auth/drizzle-adapter`, `resend` 追加
+- `lib/db/schema.ts` に Auth.js 4テーブル追加
+- `lib/auth/config.ts`, `lib/auth/require-user.ts`, `lib/auth/index.ts`
+- `app/api/auth/[...nextauth]/route.ts`
+- `app/login/page.tsx`
+- `middleware.ts`
+- `drizzle/0001_add_auth_tables.sql` 生成・適用
+
+**受け入れ条件**:
+- `/` にアクセス → 未ログインなら `/login` にリダイレクト
+- Google ログイン → `/` に戻る
+- Email Magic Link → メールが届きクリックで `/` に戻る
+- ログアウト → `/login` に戻る
+- Turso DB に session/user/account 行が作成される
+- `/offline`, `/login`, `/api/auth/*` は未認証でアクセス可能
+
+**テスト**:
+- `middleware.ts` の matcher ロジックのユニットテスト（モック session）
+- `requireUser()` の redirect 挙動テスト
+
+---
+
+### スライス 2: DB スキーマへの user_id 追加 + backfill
+
+**目的**: `bean` / `brew` テーブルに `user_id` 列（nullable）を追加。初回サインイン時の自動 backfill ロジックを実装。
+
+**対象ファイル**:
+- `lib/db/schema.ts` の `beansTable` / `brewsTable` に `userId` 追加
+- `lib/auth/config.ts` の `signIn` callback に backfill ロジック追加
+- `drizzle/0002_add_user_id_nullable.sql` 生成・適用
+
+**受け入れ条件**:
+- マイグレーション適用後、既存の bean/brew 行に `user_id = NULL` が入っている
+- 1人目のユーザーがサインインすると、`user_id IS NULL` の全 bean/brew がそのユーザーに割り当てられる
+- 2人目以降はすでに NULL 行がないため backfill は何もしない（冪等）
+
+**テスト**:
+- backfill ロジックの単体テスト（DB モック、1行/0行/複数行のケース）
+- 2回 backfill を実行しても影響がないことの確認
+
+---
+
+### スライス 3: Repository 層の user スコープ化
+
+**目的**: `BeansRepository` / `BrewsRepository` のすべてのメソッドが `userId: string` を受け取り、クエリに `WHERE user_id = userId` を適用する。
+
+**対象ファイル**:
+- `app/beans/repository.ts` — 全メソッドシグネチャ変更
+- `app/brews/repository.ts` — 全メソッドシグネチャ変更
+
+**受け入れ条件**:
+- TypeScript コンパイルが通る（userId 引数が必須のため呼び出し元がコンパイルエラーになる → 後続スライスで修正）
+- Repository の各メソッドのユニットテストで、正しい userId フィルタが掛かることを確認
+- 別ユーザーの bean_id を findById に渡すと undefined が返ること
+
+**テスト**:
+- `findById` に正しい userId + 存在する id → Bean を返す
+- `findById` に誤った userId + 存在する id → undefined を返す
+- `findAll` に userId を渡すと自分のデータのみ返る
+- `create` に userId を渡すと DB 行に user_id が設定される
+
+---
+
+### スライス 4: Service / Route Handler / Server Component への波及
+
+**目的**: 全 Service メソッドに `userId` 引数追加。Route Handler で `getAuthenticatedUser()` を呼び `401` または Service 呼び出し。Server Component で `requireUser()` を呼び Service に userId を渡す。
+
+**対象ファイル**:
+- `app/beans/service.ts`, `app/brews/service.ts`
+- `app/api/beans/route.ts`, `app/api/beans/[id]/route.ts`
+- `app/api/brews/route.ts`, `app/api/brews/[id]/route.ts`
+- `app/api/beans/extract/route.ts`
+- `app/api/flavors/route.ts`
+- `app/page.tsx`, `app/beans/[id]/page.tsx`, `app/beans/[id]/edit/page.tsx`
+- `app/brews/[id]/page.tsx`, `app/brews/[id]/edit/page.tsx`
+- `app/new/page.tsx`
+
+**受け入れ条件**:
+- ログイン済みユーザーが `/api/beans` を叩くと自分の bean のみ返る
+- 未認証リクエストに `401` が返る
+- ホームページにアクセスすると自分のデータのみ表示される
+- TypeScript コンパイルが通る
+
+**テスト**:
+- Route Handler のテスト（既存の `route.test.ts` パターンに倣い、`getAuthenticatedUser` をモック）
+  - 認証あり → Service 呼び出し
+  - 認証なし → 401
+- `flavors` は認証必須だが userId フィルタは不要（全件返す）
+
+---
+
+### スライス 5: 他人リソース 404 化の整合性確認
+
+**目的**: 他人の bean_id / brew_id を直接叩いた場合に必ず 404 が返ることを end-to-end で確認。スライス 3-4 の実装が正しく機能しているかの整合性テスト。
+
+**対象ファイル**:
+- `app/api/beans/[id]/route.ts` のテスト追加
+- `app/api/brews/[id]/route.ts` のテスト追加
+
+**受け入れ条件**:
+- `GET /api/beans/:id` で他人の id → 404
+- `PUT /api/beans/:id` で他人の id → 404
+- `DELETE /api/beans/:id` で他人の id → 404（cascade 削除されない）
+- 同様に `/api/brews/:id` でも 404
+
+**テスト**:
+- ユーザー A の bean_id でユーザー B としてリクエスト → 404
+- findById が undefined を返すと Route が 404 を返すパス
+
+---
+
+### スライス 6: user_id NOT NULL 化
+
+**目的**: 全行に user_id が設定されたことを確認後、NOT NULL 制約を適用。
+
+**対象ファイル**:
+- `lib/db/schema.ts` の `userId` を `.notNull()` に変更
+- `drizzle/0004_user_id_not_null.sql` — SQLite のテーブル再作成 SQL
+- `app/beans/repository.ts`, `app/brews/repository.ts` の型反映
+
+**受け入れ条件**:
+- マイグレーション適用後、`bean.user_id IS NULL` のクエリが 0 行を返す
+- TypeScript 上で `userId` が `string | null` ではなく `string` として扱える
+- backfill が完了していないと 0002 の INSERT が失敗する = 安全チェック
+
+**テスト**:
+- `create` 時に userId が必ず埋まること（型チェックで保証）
+
+---
+
+## 9. 既知のリスクと検出方法
+
+### リスク 1: 他人データ漏洩（Repository の user_id 付け忘れ）
+
+**リスク**: Repository のクエリに `WHERE user_id = userId` を付け忘れると、全ユーザーのデータが返る。
+
+**検出方法**:
+- TypeScript のシグネチャで `userId: string` を必須引数にしているため、コンパイルエラーで検出可能（ただし、関数内でクエリに使わない場合はランタイムまで気づかない）
+- スライス 3 のユニットテストで「誤った userId → undefined/空配列」を必ずテストする
+- PR レビューチェックリストに「全 WHERE 句に user_id フィルタがあるか」を追加
+
+### リスク 2: セッション取得漏れ（Route Handler で requireUser を呼ばない）
+
+**リスク**: Route Handler で `getAuthenticatedUser()` の呼び出しを忘れると、middleware を通過した後に認証なしで Service が呼ばれる。
+
+**検出方法**:
+- スライス 4 のテストで、認証モックなし → 401 を必ずテストする
+- ESLint カスタムルール（将来）: `app/api/**/route.ts` に `getAuthenticatedUser` の呼び出しが必ずあることを確認（将来的な追加）
+- 統合テストで未認証リクエストを全エンドポイントに対して実行
+
+### リスク 3: migration 失敗時のロールバック
+
+**リスク**:
+- `0002` (user_id nullable 追加) は `ALTER TABLE` のみ。失敗した場合は手動で `ALTER TABLE bean DROP COLUMN user_id` を実行（SQLite 3.35 以降対応）。
+- `0004` (NOT NULL 化) はテーブル再作成を伴う。失敗時に元テーブルが消えていると復旧が困難。
+
+**検出方法 / 対処**:
+- `0004` 実行前に必ず本番 DB のバックアップを取る（Turso のスナップショット機能）
+- `0004` の SQL は、まず `bean_new` 作成 → INSERT → DROP 元テーブル の順にし、INSERT が 1 行でも失敗したらトランザクションをロールバックする設計にする
+- backfill が完全に完了してから `0004` を適用する（`SELECT COUNT(*) FROM bean WHERE user_id IS NULL` が 0 を返すことを確認）
+
+### リスク 4: PWA キャッシュにログイン状態が残る
+
+**リスク**: ログアウト後も Service Worker のキャッシュにアプリシェルが残り、別ユーザーが同じデバイスでログインした際に前のユーザーの UI が一瞬見える。
+
+**検出方法 / 対処**:
+- `/api/` はキャッシュなしのため、API レスポンスは常にサーバーから取得される。問題は UI シェル（静的 JS/CSS）のみ。
+- 静的アセットにはユーザー固有の内容が含まれないため、原則として問題なし。
+- ログアウト後に `caches.delete(CACHE_NAME)` を呼び出すサービスワーカーのメッセージイベントを将来的に追加することを検討。現時点では優先度低。
+
+### リスク 5: Auth.js v5 beta の不安定性
+
+**リスク**: `next-auth@5` は 2025 年時点でまだ beta。Drizzle Adapter (`@auth/drizzle-adapter`) の SQLite 向けスキーマが変更される可能性。
+
+**検出方法 / 対処**:
+- `@auth/drizzle-adapter` の `README` にある SQLite スキーマを実装前に最終確認する
+- `package.json` の `next-auth` バージョンをピン止め（`"next-auth": "5.0.0-beta.X"` の形式）
+- Auth.js の CHANGELOG を購読してマイグレーション影響を早期検知する
+
+---
+
+## 10. 環境変数の追加一覧
+
+`.env.example` に追加する項目:
+
+```bash
+# Auth.js
+AUTH_SECRET=                    # openssl rand -base64 32 で生成。必須。
+AUTH_GOOGLE_ID=                 # Google Cloud Console の OAuth クライアント ID
+AUTH_GOOGLE_SECRET=             # Google Cloud Console の OAuth クライアントシークレット
+
+# Email Magic Link プロバイダ (Resend を想定)
+AUTH_RESEND_KEY=                # Resend API キー
+EMAIL_FROM=noreply@example.com  # 送信元メールアドレス
+
+# 既存（参考）
+TURSO_DATABASE_URL=
+TURSO_AUTH_TOKEN=
+ANTHROPIC_API_KEY=
+```
+
+**補足**:
+- `AUTH_SECRET` は本番環境では必ず固有のランダム値を設定する。dev 環境では Auth.js が自動生成するが、本番では明示指定が必須。
+- `AUTH_URL` (コールバック URL のベース) は Vercel デプロイでは自動設定されるが、カスタムドメイン使用時は明示指定が必要。
+
+---
+
+## 11. オープンな判断事項
+
+実装着手前にもう一度確認が必要な項目。
+
+### 11.1 backfill の実行主体
+
+**選択肢 A**: Auth.js の `signIn` callback 内でアプリが自動実行（推奨）。  
+**選択肢 B**: 管理者が手動 SQL を実行。
+
+既存データが本番 DB にある場合、「最初のユーザーが誰になるか」をアプリが判断できるのは A の方が安全。しかし、誤って backfill が複数回走るリスクがある（冪等性の確保が必要）。どちらにするかを確定してほしい。
+
+### 11.2 既存データが複数ユーザー分に相当する場合
+
+現在の前提は「データは1人の管理者のもの」だが、すでに複数人が使っている場合は誰に割り当てるかが不明。この前提が正しいか確認してほしい。
+
+### 11.3 `app/login/page.tsx` のデザイン
+
+最低限の機能（Google ボタン + Email フォーム）でよいか、ブランドロゴや説明文のデザインが必要かを確認。
+
+### 11.4 `flavor` の管理
+
+`flavor` は共有マスタとして認証なしでも閲覧可能にするか、認証必須のままとするか。現行設計では認証必須（middleware が全ルートを保護する）。もし `/api/flavors` を公開 API にするなら matcher から除外が必要。
+
+### 11.5 NOT NULL 化（スライス 6）のタイミング
+
+スライス 6 は「backfill 完了確認後」という条件付きで、実装とは別に運用判断が必要。スライス 5 完了後に即適用してよいか、それとも本番での運用確認期間を設けるかを決めてほしい。
+
+### 11.6 Auth.js v5 の正確なバージョンピン
+
+実装開始時点での `next-auth@5` の最新 beta バージョン番号と `@auth/drizzle-adapter` のバージョンを確認し、`package.json` にピン止めすること。
+

--- a/docs/auth-test-plan.md
+++ b/docs/auth-test-plan.md
@@ -1,0 +1,1041 @@
+# Auth Test Plan — Issue #82 (Slices 1–5)
+
+ブランチ: `feat/82-auth-per-user-data`
+
+---
+
+## 1. Scope
+
+### 対象スライス
+
+| スライス | 内容 |
+|---|---|
+| Slice 1 | Auth.js 基盤（middleware、requireUser / getAuthenticatedUser ヘルパ、ログインページ） |
+| Slice 2 | DB スキーマへの user_id 追加 + signIn callback による backfill ロジック |
+| Slice 3 | Repository 層の userId スコープ化（BeansRepository / BrewsRepository） |
+| Slice 4 | Service / Route Handler / Server Component への userId 伝搬 + 未認証 401 |
+| Slice 5 | 他人リソースへのアクセス 404 化（GET/PUT/DELETE）の整合性確認 |
+
+### スコープ外
+
+- **Slice 6 (NOT NULL 化)**: 別 PR に切り出す。このテスト計画ではスコープ外。テスト除外項目一覧（セクション 5）に記載。
+- 実 OAuth フロー / 実メール送信（Resend）
+- Drizzle Adapter の実 DB 動作確認
+- PWA オフライン時の認証挙動
+- マイグレーション SQL ファイルの内容検証
+
+---
+
+## 2. 共通セットアップ
+
+### 2.1 Vitest 環境の選択方針
+
+- **Node.js 環境 (`// @vitest-environment node`)**: Route Handler テスト、Repository テスト、ヘルパユニットテスト。`app/api/**/route.test.ts`、`app/beans/repository.test.ts`、`app/brews/repository.test.ts`、`lib/auth/require-user.test.ts` はすべてファイル先頭に `// @vitest-environment node` を付ける。
+- **jsdom 環境（デフォルト）**: Server Component レンダリングテスト（`app/page.render.test.tsx`、`app/login/page.render.test.tsx`）。
+
+### 2.2 Drizzle テスト方針（Repository テストに適用）
+
+**推奨: in-memory libsql (`better-sqlite3` または `@libsql/client` の `:memory:` モード)**
+
+`app/api/brews/route.test.ts` の既存テストは Drizzle の実装を直接呼ばず、Service をモックしている（`vi.mock('@/app/brews/service', ...)`）。Repository テスト（Slice 3）はこれとは逆に、**実際の Drizzle クエリが正しい WHERE 句を生成することを検証する**必要があるため、in-memory DB を使う。
+
+セットアップ方針:
+1. `better-sqlite3` の `:memory:` インスタンスを `drizzle(new Database(':memory:'))` で生成。
+2. テスト開始時に `CREATE TABLE` を直接 SQL で実行するか、Drizzle の `migrate()` を使用してスキーマを展開。
+3. 各テスト（または `beforeEach`）で DB をクリアして独立性を保つ。
+4. `lib/db/drizzle.ts` をモックして in-memory DB インスタンスを注入するか、Repository のコンストラクタで DB を受け取れるよう設計する（設計優先）。
+
+`vi.mock('@/lib/db/drizzle', () => ({ db: inMemoryDb }))` パターンで `db` を差し替えるのが最もシンプルで既存スタイルに合う。`vi.hoisted` で DB インスタンスを定義してから `vi.mock` ファクトリ内で参照すること（`createBrewMock` の既存パターンと同様）。
+
+### 2.3 `auth` / `requireUser` / `getAuthenticatedUser` のモック戦略
+
+```
+// Slice 1 ヘルパテスト: auth() 自体をモック
+vi.mock('@/lib/auth', () => ({
+  auth: authMock,
+}))
+
+// Slice 4 Route Handler テスト: getAuthenticatedUser をモック
+vi.mock('@/lib/auth/require-user', () => ({
+  getAuthenticatedUser: getAuthenticatedUserMock,
+}))
+
+// Slice 4 Server Component テスト: requireUser をモック
+vi.mock('@/lib/auth/require-user', () => ({
+  requireUser: requireUserMock,
+}))
+```
+
+`vi.hoisted` パターンで mock 関数を先に定義し、`vi.mock` ファクトリから参照する（既存 `route.test.ts` の `createBrewMock` パターンを踏襲）。
+
+### 2.4 Next.js Request モックの書き方
+
+既存 `route.test.ts` に倣い、`new Request(url, { method, headers, body })` を直接使う。Next.js の `NextRequest` は使わない（Node.js 標準の `Request` で十分）。
+
+```typescript
+function createRequest(method: string, url: string, body?: object) {
+  return new Request(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+}
+```
+
+### 2.5 `server-only` モック
+
+Repository / Service はすべて `import 'server-only'` を持つ。Node 環境テストで `vi.mock('server-only', () => ({}))` を追加する（既存 `route.test.ts` の extract テストに倣う）。
+
+---
+
+## 3. スライス別テスト計画
+
+---
+
+### Slice 1: Auth.js 基盤
+
+#### 3.1.1 スライスの目的
+
+`middleware.ts` の未認証リダイレクトロジックと、`requireUser()` / `getAuthenticatedUser()` の 2 ヘルパが設計通りに動作することを確認する。ログインページが必要な UI 要素を持つことを render テストで確認する。
+
+#### 3.1.2 テストファイル一覧
+
+| ファイルパス | 新規/変更 |
+|---|---|
+| `/Users/yuji/Documents/GitHub/brewia-issue-82/middleware.test.ts` | 新規 |
+| `/Users/yuji/Documents/GitHub/brewia-issue-82/lib/auth/require-user.test.ts` | 新規 |
+| `/Users/yuji/Documents/GitHub/brewia-issue-82/app/login/page.render.test.tsx` | 新規 |
+
+#### 3.1.3 テスト仕様
+
+---
+
+**ファイル: `middleware.test.ts`**
+
+```
+// @vitest-environment node
+```
+
+前提モック:
+```typescript
+vi.mock('@/lib/auth', () => ({
+  auth: vi.fn(), // middleware の export default が auth(handler) の形なのでラッパをモック
+}))
+```
+
+注意: `middleware.ts` は `auth((req) => { ... })` の高階関数パターンを使う。テストでは auth の戻り値となる内側ハンドラ関数のロジックをテストするため、ハンドラを直接 export するか、ロジックを純粋関数 `handleMiddlewareRequest(req, isLoggedIn)` に切り出してテストする方式を推奨する（後者の方が auth のモックが不要になる）。
+
+```
+describe('middleware request handler', () => {
+  describe('公開ルート（認証不要）', () => {
+    it('M1: /api/auth/callback/google へのリクエストは isLoggedIn=false でも通過する（undefined を返す）')
+    // Arrange: req.nextUrl.pathname = '/api/auth/callback/google', isLoggedIn = false
+    // Act: ハンドラを呼び出す
+    // Assert: 戻り値が undefined（=通過）であること
+
+    it('M2: /login へのリクエストは isLoggedIn=false でも通過する')
+    // Arrange: req.nextUrl.pathname = '/login', isLoggedIn = false
+    // Assert: 戻り値が undefined
+
+    it('M3: /offline へのリクエストは isLoggedIn=false でも通過する')
+    // Arrange: req.nextUrl.pathname = '/offline', isLoggedIn = false
+    // Assert: 戻り値が undefined
+  })
+
+  describe('保護ルート + 未認証', () => {
+    it('M4: / へのリクエストは isLoggedIn=false のとき /login へリダイレクトする')
+    // Arrange: req.nextUrl.pathname = '/', req.url = 'http://localhost/', isLoggedIn = false
+    // Act: ハンドラを呼び出す
+    // Assert: 戻り値が Response であり、status=302 かつ Location ヘッダが '/login' を含む
+
+    it('M5: /beans/xxx へのリクエストは isLoggedIn=false のとき /login へリダイレクトする')
+    // Arrange: req.nextUrl.pathname = '/beans/some-id', isLoggedIn = false
+    // Assert: リダイレクトレスポンス
+
+    it('M6: /api/beans へのリクエストは isLoggedIn=false のとき /login へリダイレクトする')
+    // Arrange: req.nextUrl.pathname = '/api/beans', isLoggedIn = false
+    // Assert: リダイレクトレスポンス
+  })
+
+  describe('保護ルート + 認証済み', () => {
+    it('M7: / へのリクエストは isLoggedIn=true のとき通過する（undefined を返す）')
+    // Arrange: req.nextUrl.pathname = '/', isLoggedIn = true
+    // Assert: 戻り値が undefined
+
+    it('M8: /api/beans へのリクエストは isLoggedIn=true のとき通過する')
+    // Arrange: req.nextUrl.pathname = '/api/beans', isLoggedIn = true
+    // Assert: 戻り値が undefined
+  })
+
+  describe('matcher 対象外のパス（パターン確認）', () => {
+    it('M9: matcher の正規表現が _next/static を除外することを確認する')
+    // Arrange: パス = '/_next/static/chunks/main.js'
+    // Assert: matcher の regex にマッチしない（regex を直接 test() する）
+
+    it('M10: matcher の正規表現が sw.js を除外することを確認する')
+    // Arrange: パス = '/sw.js'
+    // Assert: matcher の regex にマッチしない
+  })
+})
+```
+
+---
+
+**ファイル: `lib/auth/require-user.test.ts`**
+
+```
+// @vitest-environment node
+```
+
+前提モック:
+```typescript
+vi.mock('@/lib/auth', () => ({ auth: authMock }))
+vi.mock('next/navigation', () => ({ redirect: redirectMock }))
+```
+
+```
+describe('requireUser()', () => {
+  it('RU1: セッションに user.id が存在するとき AuthenticatedUser を返す')
+  // Arrange: authMock.mockResolvedValue({ user: { id: 'user-1', email: 'a@example.com', name: 'Alice' } })
+  // Act: const user = await requireUser()
+  // Assert: user.id === 'user-1', user.email === 'a@example.com', user.name === 'Alice'
+  // Assert: redirectMock が呼ばれていない
+
+  it('RU2: セッションが null のとき redirect("/login") を呼び出す')
+  // Arrange: authMock.mockResolvedValue(null)
+  // Act: await requireUser()
+  // Assert: redirectMock が "/login" で呼ばれている
+
+  it('RU3: セッションに user.id がない（user オブジェクトは存在する）とき redirect("/login") を呼び出す')
+  // Arrange: authMock.mockResolvedValue({ user: { email: 'a@example.com' } }) // id なし
+  // Act: await requireUser()
+  // Assert: redirectMock が "/login" で呼ばれている
+
+  it('RU4: user.name が null の場合は name: null を返す')
+  // Arrange: authMock.mockResolvedValue({ user: { id: 'user-1', email: 'a@example.com', name: null } })
+  // Act: const user = await requireUser()
+  // Assert: user.name === null
+})
+
+describe('getAuthenticatedUser()', () => {
+  it('GAU1: セッションに user.id が存在するとき AuthenticatedUser を返す')
+  // Arrange: authMock.mockResolvedValue({ user: { id: 'user-1', email: 'a@example.com', name: 'Alice' } })
+  // Act: const user = await getAuthenticatedUser()
+  // Assert: user が null でない、user.id === 'user-1'
+
+  it('GAU2: セッションが null のとき null を返す（redirect しない）')
+  // Arrange: authMock.mockResolvedValue(null)
+  // Act: const user = await getAuthenticatedUser()
+  // Assert: user === null
+  // Assert: redirectMock が呼ばれていない
+
+  it('GAU3: セッションに user.id がないとき null を返す')
+  // Arrange: authMock.mockResolvedValue({ user: { email: 'a@example.com' } })
+  // Act: const user = await getAuthenticatedUser()
+  // Assert: user === null
+})
+```
+
+---
+
+**ファイル: `app/login/page.render.test.tsx`**
+
+```
+// jsdom 環境（デフォルト）
+```
+
+前提モック:
+```typescript
+vi.mock('@/lib/auth', () => ({ auth: authMock, signIn: vi.fn() }))
+vi.mock('next/navigation', () => ({ redirect: redirectMock }))
+// next/font/google はレイアウトと同様にモック
+```
+
+```
+describe('LoginPage', () => {
+  it('LP1: 未認証状態でレンダリングしたとき Google ログインボタンが存在する')
+  // Arrange: authMock.mockResolvedValue(null)
+  // Act: render(<LoginPage />)
+  // Assert: screen.getByRole('button', { name: /Google/ }) または getByText(/Google/) が存在する
+
+  it('LP2: 未認証状態でレンダリングしたとき Email 入力フィールドが存在する')
+  // Arrange: authMock.mockResolvedValue(null)
+  // Act: render(<LoginPage />)
+  // Assert: screen.getByRole('textbox', { name: /email/i }) または getByPlaceholderText(/email/i) が存在する
+
+  it('LP3: 認証済み状態でレンダリングしたとき redirect("/") が呼ばれる')
+  // Arrange: authMock.mockResolvedValue({ user: { id: 'user-1', email: 'a@example.com' } })
+  // Act: render(<LoginPage />)  ※ または LoginPage() を直接 await して呼び出す（Server Component のため）
+  // Assert: redirectMock が "/" で呼ばれている
+})
+```
+
+#### 3.1.4 red にするための順序と最小 green
+
+1. まず `lib/auth/require-user.test.ts` の RU1〜RU4、GAU1〜GAU3 を書く（ファイルが存在しないので即 red）。
+2. `lib/auth/require-user.ts` を実装して green にする（`auth()` 呼び出しと null ガード + redirect のみ）。
+3. `middleware.test.ts` の M1〜M8 を書く（`middleware.ts` が存在しないので red）。
+4. `middleware.ts` を実装して green にする。
+5. `app/login/page.render.test.tsx` の LP1〜LP2 を書く（`app/login/page.tsx` が存在しないので red）。
+6. `app/login/page.tsx` を最小実装（ボタンと input フィールドのみ）して green にする。
+
+#### 3.1.5 受け入れ条件との対応
+
+| 受け入れ条件 | カバーするテスト |
+|---|---|
+| `/` 未ログイン → `/login` リダイレクト | M4 |
+| `/offline`, `/login`, `/api/auth/*` は未認証でアクセス可能 | M1, M2, M3 |
+| `requireUser()` 未認証 → redirect | RU2, RU3 |
+| `requireUser()` 認証済み → user 返却 | RU1, RU4 |
+| `getAuthenticatedUser()` 未認証 → null | GAU2, GAU3 |
+| Google ログインボタンが存在 | LP1 |
+| Email Magic Link フォームが存在 | LP2 |
+| ログイン済みで /login → / へリダイレクト | LP3 |
+
+#### 3.1.6 除外項目
+
+- 実 Google OAuth コールバックフロー（E2E レベル、手動確認）
+- 実 Resend メール送信（手動確認）
+- Drizzle Adapter による session/user/account テーブルへの書き込み確認（手動確認）
+- `lib/auth/config.ts` の providers/adapter 設定内容のテスト（Auth.js 内部実装に依存するため）
+
+---
+
+### Slice 2: DB スキーマ + backfill
+
+#### 3.2.1 スライスの目的
+
+`signIn` callback から切り出した backfill 純粋関数（`performBackfill(userId, db)`）が、`user_id IS NULL` の行を正しく当該ユーザーに割り当て、冪等に動作することを確認する。
+
+#### 3.2.2 テストファイル一覧
+
+| ファイルパス | 新規/変更 |
+|---|---|
+| `/Users/yuji/Documents/GitHub/brewia-issue-82/lib/auth/backfill.test.ts` | 新規 |
+
+#### 3.2.3 テスト仕様
+
+**ファイル: `lib/auth/backfill.test.ts`**
+
+```
+// @vitest-environment node
+```
+
+前提: backfill ロジックは `lib/auth/backfill.ts` に `performBackfill(userId: string, db: DrizzleDB): Promise<void>` として切り出す。この関数を `signIn` callback から呼び出す設計にする。
+
+モック戦略: Slice 3 と同様に in-memory DB を使う。`better-sqlite3` + Drizzle の `:memory:` インスタンスで `bean` / `brew` テーブルを作成し、テストデータを直接 INSERT する。
+
+```
+describe('performBackfill()', () => {
+  describe('正常系: user_id IS NULL の行が存在する', () => {
+    it('BF1: bean テーブルに user_id IS NULL の行が 1 件あるとき、その行の user_id が引数の userId に更新される')
+    // Arrange: db に bean 行 { id: 'bean-1', user_id: null } を INSERT
+    // Act: await performBackfill('user-1', db)
+    // Assert: SELECT user_id FROM bean WHERE id = 'bean-1' の結果が 'user-1'
+
+    it('BF2: brew テーブルに user_id IS NULL の行が 1 件あるとき、その行の user_id が引数の userId に更新される')
+    // Arrange: db に bean と brew 行を INSERT（brew.user_id = null）
+    // Act: await performBackfill('user-1', db)
+    // Assert: SELECT user_id FROM brew WHERE id = 'brew-1' の結果が 'user-1'
+
+    it('BF3: bean と brew の両方に NULL 行が複数あるとき、すべての行が userId に更新される')
+    // Arrange: bean 2件・brew 3件を user_id = null で INSERT
+    // Act: await performBackfill('user-1', db)
+    // Assert: SELECT COUNT(*) FROM bean WHERE user_id IS NULL が 0
+    // Assert: SELECT COUNT(*) FROM brew WHERE user_id IS NULL が 0
+  })
+
+  describe('冪等性', () => {
+    it('BF4: 同じ userId で 2 回 performBackfill を実行しても結果が変わらない')
+    // Arrange: bean 行 { id: 'bean-1', user_id: null } を INSERT
+    // Act: await performBackfill('user-1', db) を 2 回実行
+    // Assert: SELECT user_id FROM bean WHERE id = 'bean-1' が 'user-1'（2回目で別値に変わらない）
+    // Assert: SELECT COUNT(*) FROM bean WHERE user_id IS NULL が 0
+
+    it('BF5: すでに user_id が設定されている行は上書きされない')
+    // Arrange: bean 行 { id: 'bean-existing', user_id: 'original-user' } を INSERT
+    // Act: await performBackfill('new-user', db)
+    // Assert: SELECT user_id FROM bean WHERE id = 'bean-existing' が依然 'original-user'
+  })
+
+  describe('0 件ケース', () => {
+    it('BF6: user_id IS NULL の行が 0 件のとき エラーにならず正常終了する')
+    // Arrange: bean と brew に user_id が設定済みの行のみ存在（または空テーブル）
+    // Act: await performBackfill('user-1', db)
+    // Assert: エラーがスローされない、テーブルの行数が変わらない
+  })
+})
+```
+
+#### 3.2.4 red にするための順序と最小 green
+
+1. `lib/auth/backfill.test.ts` の BF1 を書く（`lib/auth/backfill.ts` が存在しないので red）。
+2. `performBackfill` を実装して BF1 を green にする。
+3. BF2〜BF6 を追加してすべて green にする。
+
+#### 3.2.5 受け入れ条件との対応
+
+| 受け入れ条件 | カバーするテスト |
+|---|---|
+| 1人目サインイン → NULL 行が全てそのユーザーに割り当てられる | BF1, BF2, BF3 |
+| 2人目以降は NULL 行がないため backfill が何もしない（冪等） | BF4, BF6 |
+| user_id 設定済み行は上書きされない | BF5 |
+
+#### 3.2.6 除外項目
+
+- `lib/db/schema.ts` への `userId` カラム追加の検証（型チェック + マイグレーション生成で確認）
+- `drizzle/0002_add_user_id_nullable.sql` の SQL 内容テスト（マイグレーション生成は手動確認）
+- `signIn` callback との統合（Auth.js の callback 内呼び出し）は手動確認
+
+---
+
+### Slice 3: Repository 層の userId スコープ化
+
+#### 3.3.1 スライスの目的
+
+`BeansRepository` および `BrewsRepository` のすべてのメソッドが `userId` を必須引数として受け取り、クエリに `WHERE user_id = userId` を適用することをテストで確認する。他ユーザーの行がクエリ結果に含まれないことを構造的に保証する。
+
+#### 3.3.2 テストファイル一覧
+
+| ファイルパス | 新規/変更 |
+|---|---|
+| `/Users/yuji/Documents/GitHub/brewia-issue-82/app/beans/repository.test.ts` | 新規 |
+| `/Users/yuji/Documents/GitHub/brewia-issue-82/app/brews/repository.test.ts` | 新規 |
+
+#### 3.3.3 テスト仕様
+
+**ファイル: `app/beans/repository.test.ts`**
+
+```
+// @vitest-environment node
+```
+
+モック戦略: in-memory DB を使用。`vi.hoisted` で `better-sqlite3` の `:memory:` DB インスタンスを生成し、`vi.mock('@/lib/db/drizzle', () => ({ db: inMemoryDb }))` で注入する。`vi.mock('server-only', () => ({}))` も必要。
+
+テストデータ設定（`beforeEach`）:
+- `user-A`, `user-B` の 2 ユーザー分の bean 行を INSERT
+- `bean-A1`: userId = 'user-A'
+- `bean-A2`: userId = 'user-A'
+- `bean-B1`: userId = 'user-B'
+
+```
+describe('BeansRepository', () => {
+  describe('findAll(userId)', () => {
+    it('BR_FA1: userId="user-A" のとき user-A の bean のみ返す（user-B の bean は含まれない）')
+    // Arrange: beforeEach のテストデータ
+    // Act: const beans = await repository.findAll('user-A')
+    // Assert: beans.length === 2
+    // Assert: beans.every(b => b.userId === 'user-A') === true
+    // Assert: beans.find(b => b.id === 'bean-B1') が undefined
+
+    it('BR_FA2: 該当ユーザーの bean が 0 件のとき空配列を返す')
+    // Arrange: 'user-C' の bean は存在しない
+    // Act: const beans = await repository.findAll('user-C')
+    // Assert: beans.length === 0
+  })
+
+  describe('findById(userId, id)', () => {
+    it('BR_FI1: 正しい userId + 存在する id のとき Bean を返す')
+    // Arrange: beforeEach のテストデータ
+    // Act: const bean = await repository.findById('user-A', 'bean-A1')
+    // Assert: bean が undefined でない、bean.id === 'bean-A1'
+
+    it('BR_FI2: 誤った userId（他ユーザーの bean id）のとき undefined を返す')
+    // Arrange: beforeEach のテストデータ
+    // Act: const bean = await repository.findById('user-A', 'bean-B1')
+    // Assert: bean === undefined
+
+    it('BR_FI3: 存在しない id のとき undefined を返す')
+    // Arrange: beforeEach のテストデータ
+    // Act: const bean = await repository.findById('user-A', 'nonexistent-id')
+    // Assert: bean === undefined
+  })
+
+  describe('create(userId, input)', () => {
+    it('BR_CR1: create を呼び出すと DB 行に userId が設定される')
+    // Arrange: validBeanInput = { name: 'Ethiopia Yirgacheffe', ... }
+    // Act: const bean = await repository.create('user-A', validBeanInput)
+    // Assert: bean.userId === 'user-A' (または DB を直接 SELECT して user_id = 'user-A' を確認)
+  })
+
+  describe('update(userId, id, input)', () => {
+    it('BR_UP1: 正しい userId のとき Bean を更新して返す')
+    // Arrange: beforeEach のテストデータ
+    // Act: const bean = await repository.update('user-A', 'bean-A1', updatedInput)
+    // Assert: bean が undefined でない
+
+    it('BR_UP2: 他ユーザーの bean id を指定したとき undefined を返す（行が変更されない）')
+    // Arrange: beforeEach のテストデータ
+    // Act: const bean = await repository.update('user-A', 'bean-B1', updatedInput)
+    // Assert: bean === undefined
+    // Assert: DB で bean-B1 の内容が変わっていないこと（再 SELECT して確認）
+  })
+
+  describe('delete(userId, id)', () => {
+    it('BR_DE1: 正しい userId のとき true を返し行が削除される')
+    // Arrange: beforeEach のテストデータ
+    // Act: const result = await repository.delete('user-A', 'bean-A1')
+    // Assert: result === true
+    // Assert: DB で bean-A1 が存在しないこと
+
+    it('BR_DE2: 他ユーザーの bean id を指定したとき false を返す（行が削除されない）')
+    // Arrange: beforeEach のテストデータ
+    // Act: const result = await repository.delete('user-A', 'bean-B1')
+    // Assert: result === false
+    // Assert: DB で bean-B1 が依然存在すること
+  })
+})
+```
+
+---
+
+**ファイル: `app/brews/repository.test.ts`**
+
+```
+// @vitest-environment node
+```
+
+テストデータ設定（`beforeEach`）:
+- `bean-A1` (userId = 'user-A'), `bean-B1` (userId = 'user-B') を bean テーブルに INSERT
+- `brew-A1` (userId = 'user-A', beanId = 'bean-A1')
+- `brew-A2` (userId = 'user-A', beanId = 'bean-A1')
+- `brew-B1` (userId = 'user-B', beanId = 'bean-B1')
+
+```
+describe('BrewsRepository', () => {
+  describe('findAll(userId)', () => {
+    it('BRW_FA1: userId="user-A" のとき user-A の brew のみ返す')
+    // Act: const brews = await repository.findAll('user-A')
+    // Assert: brews.length === 2
+    // Assert: brews.find(b => b.id === 'brew-B1') が undefined
+
+    it('BRW_FA2: 該当ユーザーの brew が 0 件のとき空配列を返す')
+    // Act: const brews = await repository.findAll('user-C')
+    // Assert: brews.length === 0
+  })
+
+  describe('findByBeanId(userId, beanId)', () => {
+    it('BRW_FB1: 自分の bean の beanId を渡したとき、その bean に紐づく自分の brew を返す')
+    // Act: const brews = await repository.findByBeanId('user-A', 'bean-A1')
+    // Assert: brews.length === 2
+
+    it('BRW_FB2: 他ユーザーの bean の beanId を渡したとき空配列を返す（bean が見つからないため）')
+    // Act: const brews = await repository.findByBeanId('user-A', 'bean-B1')
+    // Assert: brews.length === 0
+    // （内部で beansRepository.findById(userId, beanId) を呼び、beam が undefined なら空配列）
+  })
+
+  describe('findById(userId, id)', () => {
+    it('BRW_FI1: 正しい userId + 存在する brew id のとき BrewWithBean を返す')
+    // Act: const brew = await repository.findById('user-A', 'brew-A1')
+    // Assert: brew が undefined でない、brew.id === 'brew-A1'
+
+    it('BRW_FI2: 他ユーザーの brew id を渡したとき undefined を返す')
+    // Act: const brew = await repository.findById('user-A', 'brew-B1')
+    // Assert: brew === undefined
+  })
+
+  describe('findCountByBeanIdMap(userId)', () => {
+    it('BRW_FC1: userId="user-A" のとき user-A の bean に紐づく brew 数のみ集計する')
+    // Act: const map = await repository.findCountByBeanIdMap('user-A')
+    // Assert: map.get('bean-A1') === 2
+    // Assert: map.has('bean-B1') === false
+  })
+
+  describe('create(userId, input)', () => {
+    it('BRW_CR1: create を呼び出すと DB 行に userId が設定される')
+    // Act: const brew = await repository.create('user-A', validBrewInput)
+    // Assert: DB で brew の user_id = 'user-A' を確認
+  })
+
+  describe('update(userId, id, input)', () => {
+    it('BRW_UP1: 他ユーザーの brew id を指定したとき undefined を返す')
+    // Act: const brew = await repository.update('user-A', 'brew-B1', updatedInput)
+    // Assert: brew === undefined
+  })
+
+  describe('delete(userId, id)', () => {
+    it('BRW_DE1: 他ユーザーの brew id を指定したとき false を返す（行が削除されない）')
+    // Act: const result = await repository.delete('user-A', 'brew-B1')
+    // Assert: result === false
+    // Assert: DB で brew-B1 が依然存在すること
+  })
+})
+```
+
+#### 3.3.4 red にするための順序と最小 green
+
+1. `app/beans/repository.test.ts` の BR_FI2（他ユーザーの id → undefined）から書き始める。これが最も端的に「userId フィルタなし → red、フィルタあり → green」を示す。
+2. `BeansRepository.findById(userId, id)` に `AND user_id = userId` を追加して green にする。
+3. BR_FA1、BR_UP2、BR_DE2 の順に追加する（どれも「他ユーザーのデータが返らない」を検証）。
+4. BrewsRepository も同様の順序で BRW_FI2 → BRW_FA1 → BRW_FB2 の順に進める。
+
+#### 3.3.5 受け入れ条件との対応
+
+| 受け入れ条件 | カバーするテスト |
+|---|---|
+| findAll に userId を渡すと自分のデータのみ返る | BR_FA1, BR_FA2, BRW_FA1 |
+| findById に誤った userId → undefined | BR_FI2, BRW_FI2 |
+| findById に正しい userId → Bean/Brew を返す | BR_FI1, BRW_FI1 |
+| create に userId を渡すと DB 行に user_id が入る | BR_CR1, BRW_CR1 |
+| update 他ユーザー行は更新不可 | BR_UP2, BRW_UP1 |
+| delete 他ユーザー行は削除されない | BR_DE2, BRW_DE1 |
+| findByBeanId 他ユーザーの bean → 空配列 | BRW_FB2 |
+
+#### 3.3.6 除外項目
+
+- Repository の TypeScript コンパイルエラー（型変更による呼び出し元のエラー）は tsc で確認、テストは不要
+- Drizzle の OR/AND クエリ生成の SQL テキスト検証（実行結果で代替）
+- `findCountByBeanIdMap` の 0 件時動作（BRW_FC1 で間接的にカバー）
+
+---
+
+### Slice 4: Service / Route Handler / Server Component への波及
+
+#### 3.4.1 スライスの目的
+
+全 Route Handler が `getAuthenticatedUser()` を呼び、未認証時に 401 を返すこと、認証済み時に userId を Service に渡すことを確認する。Server Component (`app/page.tsx`) が `requireUser()` を呼ぶことを確認する。
+
+#### 3.4.2 テストファイル一覧
+
+| ファイルパス | 新規/変更 |
+|---|---|
+| `/Users/yuji/Documents/GitHub/brewia-issue-82/app/api/beans/route.test.ts` | 新規 |
+| `/Users/yuji/Documents/GitHub/brewia-issue-82/app/api/beans/[id]/route.test.ts` | 新規 |
+| `/Users/yuji/Documents/GitHub/brewia-issue-82/app/api/brews/route.test.ts` | 変更（既存） |
+| `/Users/yuji/Documents/GitHub/brewia-issue-82/app/api/flavors/route.test.ts` | 新規 |
+| `/Users/yuji/Documents/GitHub/brewia-issue-82/app/api/beans/extract/route.test.ts` | 変更（既存） |
+| `/Users/yuji/Documents/GitHub/brewia-issue-82/app/page.render.test.tsx` | 新規 |
+
+#### 3.4.3 テスト仕様
+
+---
+
+**ファイル: `app/api/beans/route.test.ts`（新規）**
+
+```
+// @vitest-environment node
+```
+
+モック設定:
+```typescript
+const { getAuthenticatedUserMock, getBeansMock, createBeanMock } = vi.hoisted(() => ({
+  getAuthenticatedUserMock: vi.fn(),
+  getBeansMock: vi.fn(),
+  createBeanMock: vi.fn(),
+}))
+
+vi.mock('@/lib/auth/require-user', () => ({
+  getAuthenticatedUser: getAuthenticatedUserMock,
+}))
+
+vi.mock('@/app/beans/service', () => ({
+  beansService: {
+    getBeans: getBeansMock,
+    createBean: createBeanMock,
+  },
+}))
+```
+
+```
+describe('GET /api/beans', () => {
+  it('BGET1: 認証なしのとき 401 を返す')
+  // Arrange: getAuthenticatedUserMock.mockResolvedValue(null)
+  // Act: const response = await GET(createRequest('GET', 'http://localhost/api/beans'))
+  // Assert: response.status === 401
+  // Assert: getBeansMock が呼ばれていない
+
+  it('BGET2: 認証済みのとき beansService.getBeans(userId) を呼び出し 200 を返す')
+  // Arrange: getAuthenticatedUserMock.mockResolvedValue({ id: 'user-1', email: 'a@example.com', name: 'Alice' })
+  //         getBeansMock.mockResolvedValue([{ id: 'bean-1', name: 'Ethiopia' }])
+  // Act: const response = await GET(createRequest('GET', 'http://localhost/api/beans'))
+  // Assert: response.status === 200
+  // Assert: getBeansMock が 'user-1' で呼ばれている（expect(getBeansMock).toHaveBeenCalledWith('user-1')）
+})
+
+describe('POST /api/beans', () => {
+  it('BPOST1: 認証なしのとき 401 を返す')
+  // Arrange: getAuthenticatedUserMock.mockResolvedValue(null)
+  // Act: POST(createRequest('POST', ..., validBeanBody))
+  // Assert: response.status === 401
+  // Assert: createBeanMock が呼ばれていない
+
+  it('BPOST2: 認証済み + 有効なボディのとき beansService.createBean(userId, dto) を呼び出し 201 を返す')
+  // Arrange: getAuthenticatedUserMock.mockResolvedValue({ id: 'user-1', ... })
+  //         createBeanMock.mockResolvedValue({ id: 'bean-new' })
+  // Act: POST(createRequest('POST', ..., validBeanBody))
+  // Assert: response.status === 201
+  // Assert: createBeanMock が ('user-1', expect.objectContaining({ name: ... })) で呼ばれている
+
+  it('BPOST3: 認証済み + 無効なボディのとき 400 を返す（認証チェックより先にバリデーション or 後でも可）')
+  // Arrange: getAuthenticatedUserMock.mockResolvedValue({ id: 'user-1', ... })
+  // Act: POST with body = {}
+  // Assert: response.status === 400
+})
+```
+
+---
+
+**ファイル: `app/api/beans/[id]/route.test.ts`（新規）**
+
+```
+// @vitest-environment node
+```
+
+同様のモック設定 (`getAuthenticatedUser`, `beansService.getBeanById`, `updateBean`, `deleteBean`)。
+
+```
+describe('GET /api/beans/[id]', () => {
+  it('BID_GET1: 認証なしのとき 401 を返す')
+  it('BID_GET2: 認証済み + 存在する自分の id のとき 200 を返す')
+  // Assert: getBeanByIdMock が ('user-1', 'bean-1') で呼ばれている
+})
+
+describe('PUT /api/beans/[id]', () => {
+  it('BID_PUT1: 認証なしのとき 401 を返す')
+  it('BID_PUT2: 認証済み + 有効なボディのとき updateBeanMock が (userId, id, dto) で呼ばれ 200 を返す')
+})
+
+describe('DELETE /api/beans/[id]', () => {
+  it('BID_DEL1: 認証なしのとき 401 を返す')
+  it('BID_DEL2: 認証済みのとき deleteBeanMock が (userId, id) で呼ばれ 204 を返す')
+})
+```
+
+---
+
+**ファイル: `app/api/brews/route.test.ts`（既存変更）**
+
+既存の `describe('POST /api/brews', ...)` の直前に以下を追加する。既存テストは変更せず、auth 関連のテストを新たな `describe` ブロックとして追記する。
+
+追加するモック（既存 `createBrewMock` の vi.hoisted に `getAuthenticatedUserMock` を追加）:
+```typescript
+const { createBrewMock, getAuthenticatedUserMock } = vi.hoisted(() => ({
+  createBrewMock: vi.fn(),
+  getAuthenticatedUserMock: vi.fn(),
+}))
+vi.mock('@/lib/auth/require-user', () => ({
+  getAuthenticatedUser: getAuthenticatedUserMock,
+}))
+```
+
+```
+describe('POST /api/brews — 認証', () => {
+  it('BREW_AUTH1: 認証なしのとき 401 を返す')
+  // Arrange: getAuthenticatedUserMock.mockResolvedValue(null)
+  // Assert: response.status === 401
+  // Assert: createBrewMock が呼ばれていない
+
+  it('BREW_AUTH2: 認証済みのとき createBrewMock が userId を第 1 引数として呼ばれる')
+  // Arrange: getAuthenticatedUserMock.mockResolvedValue({ id: 'user-1', ... })
+  //         createBrewMock.mockResolvedValue({ id: 'brew-new' })
+  // Assert: createBrewMock が ('user-1', expect.objectContaining({ beanId: 'bean-1' })) で呼ばれている
+})
+```
+
+---
+
+**ファイル: `app/api/flavors/route.test.ts`（新規）**
+
+```
+// @vitest-environment node
+```
+
+```
+describe('GET /api/flavors', () => {
+  it('FL1: 認証なしのとき 401 を返す')
+  // Arrange: getAuthenticatedUserMock.mockResolvedValue(null)
+  // Assert: response.status === 401
+  // Assert: getFlavorsService が呼ばれていない
+
+  it('FL2: 認証済みのとき getFlavors() を呼び出し 200 を返す（userId フィルタなし）')
+  // Arrange: getAuthenticatedUserMock.mockResolvedValue({ id: 'user-1', ... })
+  //         getFlavorsServiceMock.mockResolvedValue([{ id: 'flavor-1' }])
+  // Assert: response.status === 200
+  // Assert: getFlavorsServiceMock が userId なしで呼ばれている
+  // （flavor は shared master なので userId を渡さない）
+})
+```
+
+---
+
+**ファイル: `app/api/beans/extract/route.test.ts`（既存変更）**
+
+既存テストを壊さずに以下を追加:
+
+```
+describe('POST /api/beans/extract — 認証', () => {
+  it('EXT_AUTH1: 認証なしのとき 401 を返す（ファイルが添付されていても）')
+  // Arrange: getAuthenticatedUserMock.mockResolvedValue(null)
+  //         有効な JPEG ファイルを含む FormData を作成
+  // Assert: response.status === 401
+  // Assert: extractFromImageMock が呼ばれていない
+})
+```
+
+---
+
+**ファイル: `app/page.render.test.tsx`（新規）**
+
+```
+// jsdom 環境（デフォルト）
+```
+
+モック設定:
+```typescript
+vi.mock('@/lib/auth/require-user', () => ({
+  requireUser: requireUserMock,
+}))
+vi.mock('@/app/beans/service', () => ({ beansService: { getBeans: getBeansMock } }))
+vi.mock('@/app/brews/service', () => ({ brewsService: { getBrews: getBrewsMock } }))
+// next/font/google, globals.css 等は layout.render.test.tsx と同様にモック
+```
+
+```
+describe('HomePage (Server Component)', () => {
+  it('HP1: requireUser が呼ばれる')
+  // Arrange: requireUserMock.mockResolvedValue({ id: 'user-1', ... })
+  //         getBeansMock.mockResolvedValue([])
+  //         getBrewsMock.mockResolvedValue([])
+  // Act: await HomePage() の結果を render する（または直接 await して副作用を確認）
+  // Assert: requireUserMock が呼ばれた回数 === 1
+
+  it('HP2: 未認証のとき requireUser が redirect を発動し、ページ本体がレンダリングされない')
+  // Arrange: requireUserMock.mockImplementation(() => { throw new Error('NEXT_REDIRECT') })
+  //         ※ Next.js の redirect() は NEXT_REDIRECT エラーを throw する
+  // Act: try { await HomePage() } catch {}
+  // Assert: getBeansMock が呼ばれていない（ページが redirect で中断されたため）
+
+  it('HP3: 認証済みのとき beansService.getBeans(userId) が正しい userId で呼ばれる')
+  // Arrange: requireUserMock.mockResolvedValue({ id: 'user-1', ... })
+  //         getBeansMock.mockResolvedValue([])
+  //         getBrewsMock.mockResolvedValue([])
+  // Assert: getBeansMock が 'user-1' で呼ばれている
+})
+```
+
+#### 3.4.4 red にするための順序と最小 green
+
+1. `app/api/beans/route.test.ts` の BGET1（認証なし → 401）から書き始める（最短 red）。
+2. `GET /api/beans` に `getAuthenticatedUser()` を追加し、null の場合は 401 を返して green にする。
+3. BGET2（userId が service に渡る）を追加。service シグネチャ変更を伴うため少し大きい。
+4. 他の Route Handler（beans/[id]、brews、flavors、extract）の AUTH テストを追加しながら同様に進める。
+5. 最後に `app/page.render.test.tsx` を追加（Server Component のモックが最も複雑なため後回し）。
+
+#### 3.4.5 受け入れ条件との対応
+
+| 受け入れ条件 | カバーするテスト |
+|---|---|
+| 未認証リクエストに 401 が返る | BGET1, BPOST1, BID_GET1, BID_PUT1, BID_DEL1, BREW_AUTH1, FL1, EXT_AUTH1 |
+| ログイン済みで GET /api/beans → 自分の bean のみ返る | BGET2（service に userId を渡すことを確認） |
+| flavors は認証必須だが userId フィルタ不要 | FL1, FL2 |
+| ホームページで requireUser() が呼ばれる | HP1, HP2 |
+| service に正しい userId が渡る | BGET2, BPOST2, BREW_AUTH2, HP3 |
+
+#### 3.4.6 除外項目
+
+- Service レイヤのユニットテスト（Service は Repository のパススルーであるため、Repository テストで担保）
+- `app/beans/[id]/page.tsx` 等の他 Server Component の render テスト（パターンが HP1〜HP3 と同一のため省略可。必要に応じて追加）
+- TypeScript のコンパイルエラー確認（tsc で確認、テストは不要）
+
+---
+
+### Slice 5: 他人リソース 404 化
+
+#### 3.5.1 スライスの目的
+
+認証済みユーザーが他ユーザーの bean/brew id を指定した場合に、Route Handler が 404 を返すことを確認する。Slice 3（Repository が undefined を返す）+ Slice 4（Route Handler が 404 に変換する）の統合確認。
+
+#### 3.5.2 テストファイル一覧
+
+| ファイルパス | 新規/変更 |
+|---|---|
+| `/Users/yuji/Documents/GitHub/brewia-issue-82/app/api/beans/[id]/route.test.ts` | 変更（Slice 4 で新規作成済み） |
+| `/Users/yuji/Documents/GitHub/brewia-issue-82/app/api/brews/[id]/route.test.ts` | 新規 |
+
+#### 3.5.3 テスト仕様
+
+**ファイル: `app/api/beans/[id]/route.test.ts`（Slice 4 のファイルに追加）**
+
+追加セットアップ: Service の `getBeanByIdMock`, `updateBeanMock`, `deleteBeanMock` が `undefined` / `false` を返すケースを追加。
+
+```
+describe('GET /api/beans/[id] — 他人リソース 404', () => {
+  it('B404_GET1: 認証済みだが他ユーザーの bean id を指定したとき 404 を返す')
+  // Arrange: getAuthenticatedUserMock.mockResolvedValue({ id: 'user-A', ... })
+  //         getBeanByIdMock.mockResolvedValue(undefined) // Repository が undefined を返す
+  // Act: GET request with params.id = 'bean-B1'
+  // Assert: response.status === 404
+  // Assert: getBeanByIdMock が ('user-A', 'bean-B1') で呼ばれている（403 でなく 404 を確認）
+})
+
+describe('PUT /api/beans/[id] — 他人リソース 404', () => {
+  it('B404_PUT1: 認証済みだが他ユーザーの bean id を指定したとき 404 を返す')
+  // Arrange: getAuthenticatedUserMock.mockResolvedValue({ id: 'user-A', ... })
+  //         updateBeanMock.mockResolvedValue(undefined) // Repository が undefined を返す（user_id 不一致）
+  // Act: PUT request with params.id = 'bean-B1' + valid body
+  // Assert: response.status === 404
+})
+
+describe('DELETE /api/beans/[id] — 他人リソース 404', () => {
+  it('B404_DEL1: 認証済みだが他ユーザーの bean id を指定したとき 404 を返す')
+  // Arrange: getAuthenticatedUserMock.mockResolvedValue({ id: 'user-A', ... })
+  //         deleteBeanMock.mockResolvedValue(false) // Repository が false を返す（user_id 不一致）
+  // Act: DELETE request with params.id = 'bean-B1'
+  // Assert: response.status === 404
+})
+```
+
+---
+
+**ファイル: `app/api/brews/[id]/route.test.ts`（新規）**
+
+```
+// @vitest-environment node
+```
+
+モック設定（`getAuthenticatedUser`, `brewsService.getBrewById`, `updateBrew`, `deleteBrew`）。
+
+```
+describe('GET /api/brews/[id]', () => {
+  it('BRW404_GET1: 認証なしのとき 401 を返す')
+  // Arrange: getAuthenticatedUserMock.mockResolvedValue(null)
+  // Assert: response.status === 401
+
+  it('BRW404_GET2: 認証済み + 他ユーザーの brew id のとき 404 を返す')
+  // Arrange: getAuthenticatedUserMock.mockResolvedValue({ id: 'user-A', ... })
+  //         getBrewByIdMock.mockResolvedValue(undefined)
+  // Assert: response.status === 404
+})
+
+describe('PUT /api/brews/[id]', () => {
+  it('BRW404_PUT1: 認証なしのとき 401 を返す')
+  it('BRW404_PUT2: 認証済み + 他ユーザーの brew id のとき 404 を返す')
+  // Arrange: updateBrewMock.mockResolvedValue(undefined)
+  // Assert: response.status === 404
+})
+
+describe('DELETE /api/brews/[id]', () => {
+  it('BRW404_DEL1: 認証なしのとき 401 を返す')
+  it('BRW404_DEL2: 認証済み + 他ユーザーの brew id のとき 404 を返す')
+  // Arrange: deleteBrewMock.mockResolvedValue(false)
+  // Assert: response.status === 404
+})
+```
+
+#### 3.5.4 red にするための順序と最小 green
+
+1. B404_GET1 から書き始める（`GET /api/beans/[id]` が現状 Service に userId を渡していないため即 red）。
+2. Route Handler が `getAuthenticatedUser()` を呼び、`getBeanById(userId, id)` を呼ぶよう変更して green にする。
+3. B404_PUT1、B404_DEL1 の順に進める。
+4. brews/[id] も同様の順序。
+
+#### 3.5.5 受け入れ条件との対応
+
+| 受け入れ条件 | カバーするテスト |
+|---|---|
+| GET /api/beans/:id 他人の id → 404 | B404_GET1 |
+| PUT /api/beans/:id 他人の id → 404 | B404_PUT1 |
+| DELETE /api/beans/:id 他人の id → 404（cascade 削除されない） | B404_DEL1 |
+| GET/PUT/DELETE /api/brews/:id 他人の id → 404 | BRW404_GET2, BRW404_PUT2, BRW404_DEL2 |
+
+#### 3.5.6 除外項目
+
+- 実 DB を使った cascade 削除の非実行確認（Repository テスト BR_DE2 で代替）
+- 403 が返っていないことの明示的な確認（ステータスコードが 404 であることで十分）
+
+---
+
+## 4. 受け入れ条件とテストのトレーサビリティ表
+
+| スライス | 受け入れ条件 | テスト ID |
+|---|---|---|
+| S1 | 未ログインで `/` → `/login` リダイレクト | M4 |
+| S1 | `/login`, `/api/auth/*`, `/offline` は未認証アクセス可 | M1, M2, M3 |
+| S1 | `requireUser()` セッションあり → user 返却 | RU1, RU4 |
+| S1 | `requireUser()` セッションなし → redirect('/login') | RU2, RU3 |
+| S1 | `getAuthenticatedUser()` セッションなし → null | GAU2, GAU3 |
+| S1 | ログインページに Google ボタンが存在 | LP1 |
+| S1 | ログインページに Email フォームが存在 | LP2 |
+| S1 | ログイン済みで `/login` → `/` リダイレクト | LP3 |
+| S2 | 1人目サインイン → NULL 行がそのユーザーに割り当てられる | BF1, BF2, BF3 |
+| S2 | 2回実行しても結果が変わらない（冪等） | BF4 |
+| S2 | user_id 設定済み行は上書きされない | BF5 |
+| S2 | NULL 行 0 件でもエラーにならない | BF6 |
+| S3 | findAll(userId) → 自分のデータのみ | BR_FA1, BRW_FA1 |
+| S3 | findById 正しい userId → Bean/Brew 返却 | BR_FI1, BRW_FI1 |
+| S3 | findById 誤った userId → undefined | BR_FI2, BRW_FI2 |
+| S3 | create で DB 行に userId が設定される | BR_CR1, BRW_CR1 |
+| S3 | update 他ユーザー行は更新不可 | BR_UP2, BRW_UP1 |
+| S3 | delete 他ユーザー行は削除不可 | BR_DE2, BRW_DE1 |
+| S3 | findByBeanId 他ユーザーの beanId → 空配列 | BRW_FB2 |
+| S4 | 未認証リクエスト → 401 (beans GET) | BGET1 |
+| S4 | 未認証リクエスト → 401 (beans POST) | BPOST1 |
+| S4 | 未認証リクエスト → 401 (beans/[id] GET/PUT/DELETE) | BID_GET1, BID_PUT1, BID_DEL1 |
+| S4 | 未認証リクエスト → 401 (brews POST) | BREW_AUTH1 |
+| S4 | 未認証リクエスト → 401 (flavors GET) | FL1 |
+| S4 | 未認証リクエスト → 401 (extract POST) | EXT_AUTH1 |
+| S4 | 認証済み GET /api/beans → service に userId 渡る | BGET2 |
+| S4 | 認証済み POST /api/brews → service に userId 渡る | BREW_AUTH2 |
+| S4 | flavors は全件返す（userId フィルタなし） | FL2 |
+| S4 | ホームページで requireUser() が呼ばれる | HP1 |
+| S4 | 未認証で HomePage → redirect が発動 | HP2 |
+| S4 | 認証済みで HomePage → service に userId 渡る | HP3 |
+| S5 | GET /api/beans/:id 他人 id → 404 | B404_GET1 |
+| S5 | PUT /api/beans/:id 他人 id → 404 | B404_PUT1 |
+| S5 | DELETE /api/beans/:id 他人 id → 404 | B404_DEL1 |
+| S5 | GET/PUT/DELETE /api/brews/:id 他人 id → 404 | BRW404_GET2, BRW404_PUT2, BRW404_DEL2 |
+
+---
+
+## 5. テスト除外項目一覧
+
+| 除外項目 | 理由 | 確認方法 |
+|---|---|---|
+| 実 Google OAuth フロー | 外部サービス依存・E2E レベル | 手動確認（Vercel プレビュー環境） |
+| 実 Resend メール送信 | 外部サービス依存 | 手動確認（実メール受信） |
+| Drizzle Adapter の session/user/account 書き込み | Auth.js 内部実装に依存 | 手動確認（DB 直接 SELECT） |
+| `lib/auth/config.ts` の providers/adapter 設定 | Auth.js v5 beta の API に依存 | 手動確認 + 型チェック |
+| マイグレーション SQL ファイルの内容検証 | SQL テスト環境が未整備 | 手動実行 + `SELECT COUNT(*)` 確認 |
+| PWA オフライン時の認証挙動 | Service Worker + ネットワーク状態依存 | 手動確認（Chrome DevTools offline モード） |
+| Server Component の完全レンダリングツリー | Next.js の RSC ランタイムが必要 | vitest では副作用（requireUser 呼び出し）のみ確認 |
+| `app/beans/[id]/page.tsx` 等の他 Server Component | HP1〜HP3 と同一パターンのため省略 | 必要に応じて追加、型チェックで補完 |
+| Slice 6 (NOT NULL 化) | 別 PR でスコープ外 | 別テスト計画で対応 |
+| TypeScript コンパイルエラー（シグネチャ変更の波及） | tsc で確認 | `pnpm tsc --noEmit` |
+| `findCountByBeanIdMap` の userId なし動作（現行） | Slice 3 で変更前の動作 | 変更後 BRW_FC1 でカバー |
+
+---
+
+## 6. code-writer が詰まる可能性が高いモック複雑箇所への注意点
+
+### 6.1 `middleware.ts` のテスト
+
+`middleware.ts` は `auth(handler)` の高階関数パターンを使う。`auth` 自体が `@/lib/auth` からエクスポートされるため、`vi.mock('@/lib/auth', ...)` をモジュールレベルで定義する必要がある。テストの書き方として以下の 2 択を推奨する。
+
+**推奨 A（ハンドラを分離して純粋関数テスト）**: middleware 内のロジックを `export function handleMiddlewareRequest(pathname: string, url: string, isLoggedIn: boolean): Response | undefined` として切り出す。この場合 `auth` のモックが不要になり最もシンプル。
+
+**推奨 B（auth のモック）**: `vi.hoisted` で `authCallbackCapturer` を定義し、`auth` がコールバックを受け取ってそのまま呼び出すように偽装する。複雑なため推奨 A を優先すること。
+
+### 6.2 in-memory DB のセットアップ（Repository テスト）
+
+`lib/db/drizzle.ts` は `import 'server-only'` を含む可能性がある。`vi.mock('server-only', () => ({}))` を必ず追加すること。また、`vi.mock('@/lib/db/drizzle', ...)` のファクトリ内でインスタンスを生成しようとすると hoisting の問題が起きる。`vi.hoisted` で `const testDb = drizzle(new Database(':memory:'))` を生成してからファクトリ内で参照すること。
+
+スキーマの展開については、`drizzle-kit` の `migrate()` を使うか、`CREATE TABLE` SQL を直接実行するかを選択する。後者の方が `drizzle.config.ts` への依存がなく、テスト環境での実行が安定する。
+
+### 6.3 Server Component テスト（`app/page.render.test.tsx`）
+
+Next.js の Server Component を Vitest の jsdom 環境でテストする場合、`async` コンポーネントを直接 `await ComponentFunction()` で呼び出すか、`render()` に渡すかを選択する。`redirect()` が `NEXT_REDIRECT` エラーを throw するため、HP2 のテストでは `try/catch` でエラーをキャッチしつつ、service モックが呼ばれていないことを確認する。
+
+`app/layout.render.test.tsx` の既存パターン（`vi.mock('next/font/google', ...)`, `vi.mock('./globals.css', ...)` 等）を参考に、Server Component のレンダリングに必要なモックを揃えること。
+
+### 6.4 `vi.mock` のホイスティングと `@/lib/auth/require-user` の共有
+
+Slice 4 の複数テストファイルが同一モジュール `@/lib/auth/require-user` をモックする。各テストファイルは独立した Vitest worker で動作するため問題ないが、同一ファイル内で `requireUser` と `getAuthenticatedUser` の両方をモックする場合は両方を `vi.mock` ファクトリに含めること。
+
+### 6.5 `app/api/brews/route.test.ts` の既存テストへの影響
+
+既存テストは Service をモックしているが、`getAuthenticatedUser` のモックは追加されていない。新しいモック追加後、既存テスト（BPOST 系）が auth のデフォルト戻り値（undefined = 未認証）で 401 を返すようになる可能性がある。既存テストの `beforeEach` に `getAuthenticatedUserMock.mockResolvedValue({ id: 'user-1', ... })` を追加するか、`beforeEach` で認証済み状態をデフォルトにすること。
+
+### 6.6 `app/api/brews/[id]/route.test.ts` の `params` Promise
+
+既存の `app/api/beans/[id]/route.ts` は `params: Promise<{ id: string }>` を受け取る App Router 形式。テストではハンドラを直接呼び出す際に `params: Promise.resolve({ id: 'some-id' })` を渡すこと（既存 `app/api/beans/[id]/route.ts` の実装を参照）。

--- a/drizzle/0001_curly_klaw.sql
+++ b/drizzle/0001_curly_klaw.sql
@@ -1,0 +1,38 @@
+CREATE TABLE `account` (
+	`userId` text NOT NULL,
+	`type` text NOT NULL,
+	`provider` text NOT NULL,
+	`providerAccountId` text NOT NULL,
+	`refresh_token` text,
+	`access_token` text,
+	`expires_at` integer,
+	`token_type` text,
+	`scope` text,
+	`id_token` text,
+	`session_state` text,
+	PRIMARY KEY(`provider`, `providerAccountId`),
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `session` (
+	`sessionToken` text PRIMARY KEY NOT NULL,
+	`userId` text NOT NULL,
+	`expires` integer NOT NULL,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `user` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text,
+	`email` text NOT NULL,
+	`emailVerified` integer,
+	`image` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `user_email_unique` ON `user` (`email`);--> statement-breakpoint
+CREATE TABLE `verificationToken` (
+	`identifier` text NOT NULL,
+	`token` text NOT NULL,
+	`expires` integer NOT NULL,
+	PRIMARY KEY(`identifier`, `token`)
+);

--- a/drizzle/0002_complete_magus.sql
+++ b/drizzle/0002_complete_magus.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `bean` ADD `user_id` text REFERENCES user(id);--> statement-breakpoint
+ALTER TABLE `brew` ADD `user_id` text REFERENCES user(id);

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,619 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "66b99dbb-b61b-4f86-be94-345206f6455e",
+  "prevId": "07ed8717-319a-4012-b229-d34ba05109d9",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ],
+          "name": "account_provider_providerAccountId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bean": {
+      "name": "bean",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "farm": {
+          "name": "farm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "process": {
+          "name": "process",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "variety": {
+          "name": "variety",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "roast": {
+          "name": "roast",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "roaster": {
+          "name": "roaster",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created": {
+          "name": "created",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "brew_flavor": {
+      "name": "brew_flavor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "brew_id": {
+          "name": "brew_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "flavor_id": {
+          "name": "flavor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created": {
+          "name": "created",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "brew_flavor_brew_id_brew_id_fk": {
+          "name": "brew_flavor_brew_id_brew_id_fk",
+          "tableFrom": "brew_flavor",
+          "tableTo": "brew",
+          "columnsFrom": [
+            "brew_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "brew_flavor_flavor_id_flavor_id_fk": {
+          "name": "brew_flavor_flavor_id_flavor_id_fk",
+          "tableFrom": "brew_flavor",
+          "tableTo": "flavor",
+          "columnsFrom": [
+            "flavor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "brew": {
+      "name": "brew",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bean_id": {
+          "name": "bean_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bean_weight": {
+          "name": "bean_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bean_grind": {
+          "name": "bean_grind",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "water_weight": {
+          "name": "water_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "water_temp": {
+          "name": "water_temp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "aroma": {
+          "name": "aroma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acidity": {
+          "name": "acidity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sweetness": {
+          "name": "sweetness",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "overall": {
+          "name": "overall",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created": {
+          "name": "created",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "brew_bean_id_bean_id_fk": {
+          "name": "brew_bean_id_bean_id_fk",
+          "tableFrom": "brew",
+          "tableTo": "bean",
+          "columnsFrom": [
+            "bean_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "flavor": {
+      "name": "flavor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created": {
+          "name": "created",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verificationToken": {
+      "name": "verificationToken",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "columns": [
+            "identifier",
+            "token"
+          ],
+          "name": "verificationToken_identifier_token_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,660 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ce9066c2-922c-48c8-b3d4-e90d68e15aa9",
+  "prevId": "66b99dbb-b61b-4f86-be94-345206f6455e",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ],
+          "name": "account_provider_providerAccountId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bean": {
+      "name": "bean",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "farm": {
+          "name": "farm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "process": {
+          "name": "process",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "variety": {
+          "name": "variety",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "roast": {
+          "name": "roast",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "roaster": {
+          "name": "roaster",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created": {
+          "name": "created",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bean_user_id_user_id_fk": {
+          "name": "bean_user_id_user_id_fk",
+          "tableFrom": "bean",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "brew_flavor": {
+      "name": "brew_flavor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "brew_id": {
+          "name": "brew_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "flavor_id": {
+          "name": "flavor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created": {
+          "name": "created",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "brew_flavor_brew_id_brew_id_fk": {
+          "name": "brew_flavor_brew_id_brew_id_fk",
+          "tableFrom": "brew_flavor",
+          "tableTo": "brew",
+          "columnsFrom": [
+            "brew_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "brew_flavor_flavor_id_flavor_id_fk": {
+          "name": "brew_flavor_flavor_id_flavor_id_fk",
+          "tableFrom": "brew_flavor",
+          "tableTo": "flavor",
+          "columnsFrom": [
+            "flavor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "brew": {
+      "name": "brew",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bean_id": {
+          "name": "bean_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bean_weight": {
+          "name": "bean_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bean_grind": {
+          "name": "bean_grind",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "water_weight": {
+          "name": "water_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "water_temp": {
+          "name": "water_temp",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "aroma": {
+          "name": "aroma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acidity": {
+          "name": "acidity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sweetness": {
+          "name": "sweetness",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "overall": {
+          "name": "overall",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created": {
+          "name": "created",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "brew_user_id_user_id_fk": {
+          "name": "brew_user_id_user_id_fk",
+          "tableFrom": "brew",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "brew_bean_id_bean_id_fk": {
+          "name": "brew_bean_id_bean_id_fk",
+          "tableFrom": "brew",
+          "tableTo": "bean",
+          "columnsFrom": [
+            "bean_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "flavor": {
+      "name": "flavor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created": {
+          "name": "created",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verificationToken": {
+      "name": "verificationToken",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "columns": [
+            "identifier",
+            "token"
+          ],
+          "name": "verificationToken_identifier_token_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,20 @@
       "when": 1774771142137,
       "tag": "0000_heavy_gladiator",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1776782176794,
+      "tag": "0001_curly_klaw",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1776782497837,
+      "tag": "0002_complete_magus",
+      "breakpoints": true
     }
   ]
 }

--- a/hooks/use-brew-timer.test.ts
+++ b/hooks/use-brew-timer.test.ts
@@ -153,7 +153,7 @@ describe('useBrewTimer', () => {
 
   // stop() from idle does not throw and status stays idle
   it('stop no-op from idle: stop() from idle does not throw and status stays idle', () => {
-    let now = 0
+    const now = 0
     const getNow = () => now
 
     const { result } = renderHook(() => useBrewTimer({ getNow }))

--- a/lib/auth/backfill.test.ts
+++ b/lib/auth/backfill.test.ts
@@ -1,0 +1,218 @@
+// @vitest-environment node
+
+import { createClient } from '@libsql/client'
+import { drizzle } from 'drizzle-orm/libsql'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { unlinkSync } from 'fs'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { performBackfill } from './backfill'
+
+/**
+ * performBackfill はトランザクションを使用する。
+ * @libsql/client の ':memory:' URL はトランザクション時に別接続を開くため、
+ * CREATE TABLE で作ったテーブルが transaction 内から見えなくなる。
+ * 回避策として一時ファイルを使用し、テスト後に削除する。
+ */
+let currentDbPath: string | null = null
+
+function createTestDb() {
+  const dbPath = join(tmpdir(), `backfill_test_${Date.now()}_${Math.random().toString(36).slice(2)}.db`)
+  currentDbPath = dbPath
+  const client = createClient({ url: `file:${dbPath}` })
+  const db = drizzle(client)
+  return { client, db }
+}
+
+async function setupSchema(client: ReturnType<typeof createClient>) {
+  // FK 制約はテスト用ダミーデータの挿入を簡単にするため無効化する
+  await client.execute(`PRAGMA foreign_keys = OFF`)
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS "user" (
+      "id" TEXT PRIMARY KEY NOT NULL,
+      "name" TEXT,
+      "email" TEXT NOT NULL UNIQUE,
+      "emailVerified" INTEGER,
+      "image" TEXT
+    )
+  `)
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS "bean" (
+      "id" TEXT PRIMARY KEY NOT NULL,
+      "user_id" TEXT REFERENCES "user"("id"),
+      "name" TEXT NOT NULL DEFAULT '',
+      "country" TEXT NOT NULL DEFAULT '',
+      "region" TEXT,
+      "farm" TEXT,
+      "process" TEXT,
+      "variety" TEXT,
+      "roast" TEXT NOT NULL DEFAULT '',
+      "roaster" TEXT,
+      "notes" TEXT,
+      "created" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updated" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+  `)
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS "brew" (
+      "id" TEXT PRIMARY KEY NOT NULL,
+      "user_id" TEXT REFERENCES "user"("id"),
+      "bean_id" TEXT NOT NULL DEFAULT '',
+      "bean_weight" REAL NOT NULL DEFAULT 0,
+      "bean_grind" REAL,
+      "water_weight" REAL NOT NULL DEFAULT 0,
+      "water_temp" REAL,
+      "steps" TEXT NOT NULL DEFAULT '[]',
+      "aroma" INTEGER NOT NULL DEFAULT 0,
+      "acidity" INTEGER NOT NULL DEFAULT 0,
+      "sweetness" INTEGER NOT NULL DEFAULT 0,
+      "body" INTEGER NOT NULL DEFAULT 0,
+      "overall" INTEGER NOT NULL DEFAULT 0,
+      "notes" TEXT,
+      "created" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updated" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+  `)
+}
+
+describe('performBackfill()', () => {
+  let client: ReturnType<typeof createClient>
+  let db: ReturnType<typeof drizzle>
+
+  beforeEach(async () => {
+    const testDb = createTestDb()
+    client = testDb.client
+    db = testDb.db
+    await setupSchema(client)
+  })
+
+  afterEach(() => {
+    // 一時ファイルを削除してテスト間の状態漏洩を防ぐ
+    if (currentDbPath) {
+      try { unlinkSync(currentDbPath) } catch { /* ignore */ }
+      try { unlinkSync(currentDbPath + '-wal') } catch { /* ignore */ }
+      try { unlinkSync(currentDbPath + '-shm') } catch { /* ignore */ }
+      currentDbPath = null
+    }
+  })
+
+  describe('正常系: user_id IS NULL の行が存在する', () => {
+    it('BF1: bean テーブルに user_id IS NULL の行が 1 件あるとき、その行の user_id が引数の userId に更新される', async () => {
+      await client.execute({
+        sql: `INSERT INTO bean (id, name, country, roast, user_id) VALUES (?, ?, ?, ?, NULL)`,
+        args: ['bean-1', 'Ethiopia', 'Ethiopia', 'Light'],
+      })
+
+      const result = await performBackfill('user-1', db)
+
+      const rows = await client.execute({
+        sql: `SELECT user_id FROM bean WHERE id = ?`,
+        args: ['bean-1'],
+      })
+      expect(rows.rows[0][0]).toBe('user-1')
+      expect(result.beansUpdated).toBe(1)
+      expect(result.brewsUpdated).toBe(0)
+    })
+
+    it('BF2: brew テーブルに user_id IS NULL の行が 1 件あるとき、その行の user_id が引数の userId に更新される', async () => {
+      await client.execute({
+        sql: `INSERT INTO bean (id, name, country, roast, user_id) VALUES (?, ?, ?, ?, NULL)`,
+        args: ['bean-1', 'Ethiopia', 'Ethiopia', 'Light'],
+      })
+      await client.execute({
+        sql: `INSERT INTO brew (id, bean_id, bean_weight, water_weight, steps, aroma, acidity, sweetness, body, overall, user_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+        args: ['brew-1', 'bean-1', 15, 240, '[]', 3, 3, 3, 3, 3],
+      })
+
+      const result = await performBackfill('user-1', db)
+
+      const rows = await client.execute({
+        sql: `SELECT user_id FROM brew WHERE id = ?`,
+        args: ['brew-1'],
+      })
+      expect(rows.rows[0][0]).toBe('user-1')
+      expect(result.brewsUpdated).toBe(1)
+    })
+
+    it('BF3: bean と brew の両方に NULL 行が複数あるとき、すべての行が userId に更新される', async () => {
+      await client.execute({
+        sql: `INSERT INTO bean (id, name, country, roast, user_id) VALUES (?, ?, ?, ?, NULL)`,
+        args: ['bean-1', 'Ethiopia', 'Ethiopia', 'Light'],
+      })
+      await client.execute({
+        sql: `INSERT INTO bean (id, name, country, roast, user_id) VALUES (?, ?, ?, ?, NULL)`,
+        args: ['bean-2', 'Kenya', 'Kenya', 'Medium'],
+      })
+      await client.execute({
+        sql: `INSERT INTO brew (id, bean_id, bean_weight, water_weight, steps, aroma, acidity, sweetness, body, overall, user_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+        args: ['brew-1', 'bean-1', 15, 240, '[]', 3, 3, 3, 3, 3],
+      })
+      await client.execute({
+        sql: `INSERT INTO brew (id, bean_id, bean_weight, water_weight, steps, aroma, acidity, sweetness, body, overall, user_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+        args: ['brew-2', 'bean-1', 15, 240, '[]', 4, 4, 4, 4, 4],
+      })
+      await client.execute({
+        sql: `INSERT INTO brew (id, bean_id, bean_weight, water_weight, steps, aroma, acidity, sweetness, body, overall, user_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+        args: ['brew-3', 'bean-2', 15, 240, '[]', 5, 5, 5, 5, 5],
+      })
+
+      const result = await performBackfill('user-1', db)
+
+      const beanNull = await client.execute(`SELECT COUNT(*) as cnt FROM bean WHERE user_id IS NULL`)
+      const brewNull = await client.execute(`SELECT COUNT(*) as cnt FROM brew WHERE user_id IS NULL`)
+      expect(Number(beanNull.rows[0][0])).toBe(0)
+      expect(Number(brewNull.rows[0][0])).toBe(0)
+      expect(result.beansUpdated).toBe(2)
+      expect(result.brewsUpdated).toBe(3)
+    })
+  })
+
+  describe('冪等性', () => {
+    it('BF4: 同じ userId で 2 回 performBackfill を実行しても結果が変わらない', async () => {
+      await client.execute({
+        sql: `INSERT INTO bean (id, name, country, roast, user_id) VALUES (?, ?, ?, ?, NULL)`,
+        args: ['bean-1', 'Ethiopia', 'Ethiopia', 'Light'],
+      })
+
+      await performBackfill('user-1', db)
+      const result2 = await performBackfill('user-1', db)
+
+      const rows = await client.execute({
+        sql: `SELECT user_id FROM bean WHERE id = ?`,
+        args: ['bean-1'],
+      })
+      expect(rows.rows[0][0]).toBe('user-1')
+
+      const nullCount = await client.execute(`SELECT COUNT(*) FROM bean WHERE user_id IS NULL`)
+      expect(Number(nullCount.rows[0][0])).toBe(0)
+
+      // 2 回目は NULL 行が 0 件なので 0 件更新
+      expect(result2.beansUpdated).toBe(0)
+    })
+
+    it('BF5: すでに user_id が設定されている行は上書きされない', async () => {
+      await client.execute({
+        sql: `INSERT INTO bean (id, name, country, roast, user_id) VALUES (?, ?, ?, ?, ?)`,
+        args: ['bean-existing', 'Ethiopia', 'Ethiopia', 'Light', 'original-user'],
+      })
+
+      await performBackfill('new-user', db)
+
+      const rows = await client.execute({
+        sql: `SELECT user_id FROM bean WHERE id = ?`,
+        args: ['bean-existing'],
+      })
+      expect(rows.rows[0][0]).toBe('original-user')
+    })
+  })
+
+  describe('0 件ケース', () => {
+    it('BF6: user_id IS NULL の行が 0 件のとき エラーにならず正常終了する', async () => {
+      // テーブルは空
+      await expect(performBackfill('user-1', db)).resolves.toEqual({
+        beansUpdated: 0,
+        brewsUpdated: 0,
+      })
+    })
+  })
+})

--- a/lib/auth/backfill.ts
+++ b/lib/auth/backfill.ts
@@ -1,0 +1,38 @@
+import { isNull } from 'drizzle-orm'
+import type { LibSQLDatabase } from 'drizzle-orm/libsql'
+import { beansTable, brewsTable } from '@/lib/db/schema'
+
+/**
+ * user_id IS NULL な bean / brew 全行を引数の userId に割り当てる。
+ * 冪等: 2 回目以降は NULL 行が 0 件なので 0 件更新になる。
+ *
+ * @param userId  割り当て先のユーザー ID
+ * @param database  Drizzle DB インスタンス（テスト時に in-memory を注入可能）
+ */
+export async function performBackfill(
+  userId: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  database: LibSQLDatabase<any>,
+): Promise<{ beansUpdated: number; brewsUpdated: number }> {
+  // トランザクションで 2 つの UPDATE をラップ。
+  // 途中で失敗した場合は両方の UPDATE がロールバックされ、
+  // 「bean は更新済みで brew は NULL のまま」という不整合が生じない。
+  return database.transaction(async (tx) => {
+    const beansResult = await tx
+      .update(beansTable)
+      .set({ userId })
+      .where(isNull(beansTable.userId))
+      .returning({ id: beansTable.id })
+
+    const brewsResult = await tx
+      .update(brewsTable)
+      .set({ userId })
+      .where(isNull(brewsTable.userId))
+      .returning({ id: brewsTable.id })
+
+    return {
+      beansUpdated: beansResult.length,
+      brewsUpdated: brewsResult.length,
+    }
+  })
+}

--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -1,0 +1,49 @@
+import NextAuth from 'next-auth'
+import { DrizzleAdapter } from '@auth/drizzle-adapter'
+import Google from 'next-auth/providers/google'
+import Resend from 'next-auth/providers/resend'
+import { db } from '@/lib/db/drizzle'
+import {
+  usersTable,
+  accountsTable,
+  sessionsTable,
+  verificationTokensTable,
+} from '@/lib/db/schema'
+import { performBackfill } from '@/lib/auth/backfill'
+
+export const { auth, handlers, signIn, signOut } = NextAuth({
+  adapter: DrizzleAdapter(db, {
+    usersTable,
+    accountsTable,
+    sessionsTable,
+    verificationTokensTable,
+  }),
+  providers: [
+    Google({
+      clientId: process.env.AUTH_GOOGLE_ID,
+      clientSecret: process.env.AUTH_GOOGLE_SECRET,
+    }),
+    Resend({
+      apiKey: process.env.AUTH_RESEND_KEY,
+      from: process.env.EMAIL_FROM ?? 'noreply@example.com',
+    }),
+  ],
+  session: {
+    strategy: 'database',
+  },
+  callbacks: {
+    session({ session, user }) {
+      if (session.user && user) {
+        session.user.id = user.id
+      }
+      return session
+    },
+  },
+  events: {
+    async signIn({ user }) {
+      if (user.id) {
+        await performBackfill(user.id, db)
+      }
+    },
+  },
+})

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -1,0 +1,1 @@
+export { auth, handlers, signIn, signOut } from './config'

--- a/lib/auth/require-user.test.ts
+++ b/lib/auth/require-user.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { authMock, redirectMock } = vi.hoisted(() => ({
+  authMock: vi.fn(),
+  redirectMock: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  auth: authMock,
+}))
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}))
+
+import { requireUser, getAuthenticatedUser } from '@/lib/auth/require-user'
+
+describe('requireUser()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('RU1: セッションに user.id が存在するとき AuthenticatedUser を返す', async () => {
+    authMock.mockResolvedValue({
+      user: { id: 'user-1', email: 'a@example.com', name: 'Alice' },
+    })
+
+    const user = await requireUser()
+
+    expect(user.id).toBe('user-1')
+    expect(user.email).toBe('a@example.com')
+    expect(user.name).toBe('Alice')
+    expect(redirectMock).not.toHaveBeenCalled()
+  })
+
+  it('RU2: セッションが null のとき redirect("/login") を呼び出す', async () => {
+    authMock.mockResolvedValue(null)
+
+    await requireUser()
+
+    expect(redirectMock).toHaveBeenCalledWith('/login')
+  })
+
+  it('RU3: セッションに user.id がない（user オブジェクトは存在する）とき redirect("/login") を呼び出す', async () => {
+    authMock.mockResolvedValue({ user: { email: 'a@example.com' } })
+
+    await requireUser()
+
+    expect(redirectMock).toHaveBeenCalledWith('/login')
+  })
+
+  it('RU4: user.name が null の場合は name: null を返す', async () => {
+    authMock.mockResolvedValue({
+      user: { id: 'user-1', email: 'a@example.com', name: null },
+    })
+
+    const user = await requireUser()
+
+    expect(user.name).toBeNull()
+  })
+})
+
+describe('getAuthenticatedUser()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('GAU1: セッションに user.id が存在するとき AuthenticatedUser を返す', async () => {
+    authMock.mockResolvedValue({
+      user: { id: 'user-1', email: 'a@example.com', name: 'Alice' },
+    })
+
+    const user = await getAuthenticatedUser()
+
+    expect(user).not.toBeNull()
+    expect(user!.id).toBe('user-1')
+  })
+
+  it('GAU2: セッションが null のとき null を返す（redirect しない）', async () => {
+    authMock.mockResolvedValue(null)
+
+    const user = await getAuthenticatedUser()
+
+    expect(user).toBeNull()
+    expect(redirectMock).not.toHaveBeenCalled()
+  })
+
+  it('GAU3: セッションに user.id がないとき null を返す', async () => {
+    authMock.mockResolvedValue({ user: { email: 'a@example.com' } })
+
+    const user = await getAuthenticatedUser()
+
+    expect(user).toBeNull()
+  })
+})

--- a/lib/auth/require-user.ts
+++ b/lib/auth/require-user.ts
@@ -1,0 +1,42 @@
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+
+export interface AuthenticatedUser {
+  id: string
+  email: string
+  name: string | null
+}
+
+/**
+ * Server Component / Server Action 用。
+ * セッションが存在しない場合は redirect('/login') を発行する。
+ */
+export async function requireUser(): Promise<AuthenticatedUser> {
+  const session = await auth()
+  if (!session?.user?.id) {
+    redirect('/login')
+    // redirect() throws in Next.js; this satisfies TypeScript in test environments
+    return undefined as never
+  }
+  return {
+    id: session.user.id,
+    email: session.user.email!,
+    name: session.user.name ?? null,
+  }
+}
+
+/**
+ * Route Handler 用。
+ * セッションが存在しない場合は null を返す（redirect しない）。
+ */
+export async function getAuthenticatedUser(): Promise<AuthenticatedUser | null> {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return null
+  }
+  return {
+    id: session.user.id,
+    email: session.user.email!,
+    name: session.user.name ?? null,
+  }
+}

--- a/lib/db/beans.ts
+++ b/lib/db/beans.ts
@@ -8,6 +8,7 @@ import { beansTable } from '@/lib/db/schema'
 function mapBeanRow(row: typeof beansTable.$inferSelect): Bean {
   return {
     ...row,
+    userId: row.userId ?? null,
     country: row.country as Bean['country'],
     roast: row.roast as Bean['roast'],
   }

--- a/lib/db/brews.ts
+++ b/lib/db/brews.ts
@@ -11,6 +11,7 @@ import type { Brew, BrewStep, BrewWithBean } from '@/lib/types'
 function mapBrewRow(row: typeof brewsTable.$inferSelect): Brew {
   return {
     ...row,
+    userId: row.userId ?? null,
     steps: parseSteps(row.steps),
   }
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,9 +1,58 @@
 import { sql } from 'drizzle-orm'
-import { integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { integer, primaryKey, real, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 import { v7 as uuidv7 } from 'uuid'
+
+// --- Auth.js テーブル群（@auth/drizzle-adapter sqlite 最新仕様準拠）---
+
+export const usersTable = sqliteTable('user', {
+  id: text('id').notNull().primaryKey(),
+  name: text('name'),
+  email: text('email').notNull().unique(),
+  emailVerified: integer('emailVerified', { mode: 'timestamp_ms' }),
+  image: text('image'),
+})
+
+export const accountsTable = sqliteTable(
+  'account',
+  {
+    userId: text('userId')
+      .notNull()
+      .references(() => usersTable.id, { onDelete: 'cascade' }),
+    type: text('type').notNull(),
+    provider: text('provider').notNull(),
+    providerAccountId: text('providerAccountId').notNull(),
+    refresh_token: text('refresh_token'),
+    access_token: text('access_token'),
+    expires_at: integer('expires_at'),
+    token_type: text('token_type'),
+    scope: text('scope'),
+    id_token: text('id_token'),
+    session_state: text('session_state'),
+  },
+  (t) => ({ pk: primaryKey({ columns: [t.provider, t.providerAccountId] }) }),
+)
+
+export const sessionsTable = sqliteTable('session', {
+  sessionToken: text('sessionToken').notNull().primaryKey(),
+  userId: text('userId')
+    .notNull()
+    .references(() => usersTable.id, { onDelete: 'cascade' }),
+  expires: integer('expires', { mode: 'timestamp_ms' }).notNull(),
+})
+
+export const verificationTokensTable = sqliteTable(
+  'verificationToken',
+  {
+    identifier: text('identifier').notNull(),
+    token: text('token').notNull(),
+    expires: integer('expires', { mode: 'timestamp_ms' }).notNull(),
+  },
+  (t) => ({ pk: primaryKey({ columns: [t.identifier, t.token] }) }),
+)
 
 export const beansTable = sqliteTable('bean', {
   id: text('id').primaryKey().$defaultFn(() => uuidv7()),
+  userId: text('user_id').references(() => usersTable.id),
   name: text('name').notNull(),
   country: text('country').notNull(),
   region: text('region'),
@@ -19,6 +68,7 @@ export const beansTable = sqliteTable('bean', {
 
 export const brewsTable = sqliteTable('brew', {
   id: text('id').primaryKey().$defaultFn(() => uuidv7()),
+  userId: text('user_id').references(() => usersTable.id),
   beanId: text('bean_id').notNull().references(() => beansTable.id),
   beanWeight: real('bean_weight').notNull(),
   beanGrind: real('bean_grind'),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -53,6 +53,7 @@ export const COUNTRY_FLAGS: Record<Country, string> = {
 
 export interface Bean {
   id: string
+  userId: string | null
   name: string
   country: Country
   region: string | null
@@ -73,6 +74,7 @@ export interface BrewStep {
 
 export interface Brew {
   id: string
+  userId: string | null
   beanId: string
   beanWeight: number
   beanGrind: number | null

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from 'vitest'
+
+// next-auth は Node.js テスト環境では next/server が解決できないためモックする
+vi.mock('@/lib/auth', () => ({
+  auth: vi.fn((handler: unknown) => handler),
+}))
+
+import { handleMiddlewareRequest, middlewareConfig } from '@/middleware'
+
+function makeReq(pathname: string, baseUrl = 'http://localhost'): { nextUrl: { pathname: string }; url: string } {
+  return {
+    nextUrl: { pathname },
+    url: `${baseUrl}${pathname}`,
+  }
+}
+
+describe('middleware request handler', () => {
+  describe('公開ルート（認証不要）', () => {
+    it('M1: /api/auth/callback/google へのリクエストは isLoggedIn=false でも通過する（undefined を返す）', () => {
+      const result = handleMiddlewareRequest(makeReq('/api/auth/callback/google'), false)
+      expect(result).toBeUndefined()
+    })
+
+    it('M2: /login へのリクエストは isLoggedIn=false でも通過する', () => {
+      const result = handleMiddlewareRequest(makeReq('/login'), false)
+      expect(result).toBeUndefined()
+    })
+
+    it('M3: /offline へのリクエストは isLoggedIn=false でも通過する', () => {
+      const result = handleMiddlewareRequest(makeReq('/offline'), false)
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('保護ルート + 未認証', () => {
+    it('M4: / へのリクエストは isLoggedIn=false のとき /login へリダイレクトする', () => {
+      const result = handleMiddlewareRequest(makeReq('/'), false)
+      expect(result).toBeInstanceOf(Response)
+      expect((result as Response).status).toBe(302)
+      expect((result as Response).headers.get('location')).toContain('/login')
+    })
+
+    it('M5: /beans/xxx へのリクエストは isLoggedIn=false のとき /login へリダイレクトする', () => {
+      const result = handleMiddlewareRequest(makeReq('/beans/some-id'), false)
+      expect(result).toBeInstanceOf(Response)
+      expect((result as Response).status).toBe(302)
+    })
+
+    it('M6: /api/beans へのリクエストは isLoggedIn=false のとき /login へリダイレクトする', () => {
+      const result = handleMiddlewareRequest(makeReq('/api/beans'), false)
+      expect(result).toBeInstanceOf(Response)
+      expect((result as Response).status).toBe(302)
+    })
+  })
+
+  describe('保護ルート + 認証済み', () => {
+    it('M7: / へのリクエストは isLoggedIn=true のとき通過する（undefined を返す）', () => {
+      const result = handleMiddlewareRequest(makeReq('/'), true)
+      expect(result).toBeUndefined()
+    })
+
+    it('M8: /api/beans へのリクエストは isLoggedIn=true のとき通過する', () => {
+      const result = handleMiddlewareRequest(makeReq('/api/beans'), true)
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('matcher 対象外のパス（パターン確認）', () => {
+    it('M9: matcher の正規表現が _next/static を除外することを確認する', () => {
+      // middlewareConfig.matcher の除外パターンを手動で検証する
+      void middlewareConfig.matcher[0]
+      const excludePattern = /(_next\/static|_next\/image|icon|manifest|sw\.js|favicon)/
+      expect(excludePattern.test('/_next/static/chunks/main.js')).toBe(true)
+    })
+
+    it('M10: matcher の正規表現が sw.js を除外することを確認する', () => {
+      const excludePattern = /(_next\/static|_next\/image|icon|manifest|sw\.js|favicon)/
+      expect(excludePattern.test('/sw.js')).toBe(true)
+    })
+  })
+})

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,43 @@
+import { auth } from '@/lib/auth'
+
+type MiddlewareReq = {
+  nextUrl: { pathname: string }
+  url: string
+}
+
+/**
+ * ミドルウェアのルーティングロジックを純粋関数として切り出す。
+ * テストで auth モックなしにロジックをテストできるようにする。
+ */
+export function handleMiddlewareRequest(
+  req: MiddlewareReq,
+  isLoggedIn: boolean,
+): Response | undefined {
+  const { pathname } = req.nextUrl
+
+  const isAuthRoute = pathname.startsWith('/api/auth')
+  const isLoginPage = pathname === '/login'
+  const isOfflinePage = pathname === '/offline'
+
+  if (isAuthRoute || isLoginPage || isOfflinePage) {
+    return undefined // 通過
+  }
+
+  if (!isLoggedIn) {
+    const loginUrl = new URL('/login', req.url)
+    return Response.redirect(loginUrl)
+  }
+
+  return undefined // 認証済み → 通過
+}
+
+export const middlewareConfig = {
+  matcher: ['/((?!_next/static|_next/image|icon|manifest|sw\\.js|favicon).*)'],
+}
+
+export default auth((req) => {
+  const isLoggedIn = !!req.auth
+  return handleMiddlewareRequest(req, isLoggedIn)
+})
+
+export const config = middlewareConfig

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
+    "@auth/drizzle-adapter": "1.11.2",
     "@hookform/resolvers": "^3.9.1",
     "@libsql/client": "^0.15.15",
     "@radix-ui/react-accordion": "1.2.12",
@@ -54,6 +55,7 @@
     "input-otp": "1.4.2",
     "lucide-react": "^0.564.0",
     "next": "16.2.0",
+    "next-auth": "5.0.0-beta.31",
     "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-day-picker": "9.13.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.90.0
         version: 0.90.0(zod@3.25.76)
+      '@auth/drizzle-adapter':
+        specifier: 1.11.2
+        version: 1.11.2
       '@hookform/resolvers':
         specifier: ^3.9.1
         version: 3.10.0(react-hook-form@7.72.0(react@19.2.4))
@@ -131,6 +134,9 @@ importers:
       next:
         specifier: 16.2.0
         version: 16.2.0(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-auth:
+        specifier: 5.0.0-beta.31
+        version: 5.0.0-beta.31(next@16.2.0(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -246,6 +252,23 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@auth/core@0.41.2':
+    resolution: {integrity: sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^7.0.7
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
+  '@auth/drizzle-adapter@1.11.2':
+    resolution: {integrity: sha512-VOuj7REI8jfJjpSbsYwDM/Zrn55T6lS9Yc+29V+EXMcel8eqG7x+7LodNfd1WHjakfkLYi+qsbYUHB3E6aDA4w==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1209,6 +1232,9 @@ packages:
 
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
+
+  '@panva/hkdf@1.2.1':
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -3329,6 +3355,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
@@ -3542,6 +3571,22 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  next-auth@5.0.0-beta.31:
+    resolution: {integrity: sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      next: ^14.0.0-0 || ^15.0.0 || ^16.0.0
+      nodemailer: ^7.0.7
+      react: ^18.2.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
     peerDependencies:
@@ -3584,6 +3629,9 @@ packages:
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+
+  oauth4webapi@3.8.5:
+    resolution: {integrity: sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -3682,6 +3730,14 @@ packages:
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  preact-render-to-string@6.5.11:
+    resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
+    peerDependencies:
+      preact: '>=10'
+
+  preact@10.24.3:
+    resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -4352,6 +4408,22 @@ snapshots:
   '@asamuzakjp/generational-cache@1.0.1': {}
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@auth/core@0.41.2':
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      jose: 6.2.2
+      oauth4webapi: 3.8.5
+      preact: 10.24.3
+      preact-render-to-string: 6.5.11(preact@10.24.3)
+
+  '@auth/drizzle-adapter@1.11.2':
+    dependencies:
+      '@auth/core': 0.41.2
+    transitivePeerDependencies:
+      - '@simplewebauthn/browser'
+      - '@simplewebauthn/server'
+      - nodemailer
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -5059,6 +5131,8 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@oxc-project/types@0.124.0': {}
+
+  '@panva/hkdf@1.2.1': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -7271,6 +7345,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.2.2: {}
+
   js-base64@3.7.8: {}
 
   js-tokens@4.0.0: {}
@@ -7467,6 +7543,12 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  next-auth@5.0.0-beta.31(next@16.2.0(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@auth/core': 0.41.2
+      next: 16.2.0(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+
   next-themes@0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -7512,6 +7594,8 @@ snapshots:
       formdata-polyfill: 4.0.10
 
   node-releases@2.0.36: {}
+
+  oauth4webapi@3.8.5: {}
 
   object-assign@4.1.1: {}
 
@@ -7617,6 +7701,12 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  preact-render-to-string@6.5.11(preact@10.24.3):
+    dependencies:
+      preact: 10.24.3
+
+  preact@10.24.3: {}
 
   prelude-ls@1.2.1: {}
 


### PR DESCRIPTION
Closes #82.

## Summary
- Adds Auth.js (NextAuth v5) with Google OAuth + Email Magic Link, persisted to Turso via `@auth/drizzle-adapter`.
- Scopes all `bean` / `brew` access to the authenticated user: every repository method requires a `userId` and enforces `WHERE user_id = ?`; route handlers return `401` without a session; server components call `requireUser()` and redirect to `/login`.
- `events.signIn` invokes `performBackfill()` inside a transaction so the first user to sign in inherits all pre-existing bean/brew rows with all-or-nothing semantics. `flavor` stays a shared master table.

## Implementation notes
- Built in 4 TDD slices (see `docs/auth-architecture.md` and `docs/auth-test-plan.md`).
- Code review caught and fixed two must-fix issues before this PR:
  - `BrewsRepository.delete` deleted `brew_flavor` rows before checking ownership, allowing a cross-user integrity attack. Reordered so the ownership-scoped `brew` delete runs first and child rows are only touched on success.
  - `performBackfill` ran two independent `UPDATE`s; now wrapped in `database.transaction` to guarantee atomicity.
- Fixes a pre-existing `prefer-const` lint error in `hooks/use-brew-timer.test.ts` so CI lint passes.

## Migrations
- `drizzle/0001_curly_klaw.sql`: Auth.js tables (`user`, `account`, `session`, `verificationToken`).
- `drizzle/0002_complete_magus.sql`: adds nullable `user_id` column to `bean` and `brew` (backfilled on first sign-in; NOT NULL tightening deliberately deferred).

## New environment variables
`AUTH_SECRET`, `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`, `AUTH_RESEND_KEY`, `EMAIL_FROM` (see `.env.example`).

## Test plan
- [x] `pnpm test` → 323 passed (middleware, `requireUser` / `getAuthenticatedUser`, backfill idempotency + atomicity, beans/brews repositories with cross-user regression, every `/api/*` route handler, `/login` and `/` render, cross-user `DELETE` integrity).
- [x] `pnpm exec tsc --noEmit` → clean.
- [x] `pnpm lint` → 0 errors (3 pre-existing warnings).
- [ ] Manual smoke: Google sign-in round-trip, Email Magic Link delivery via Resend, backfill on first login, `/api/beans/:id` returns 404 for another user's id.
- [ ] Run `pnpm db:push` (or equivalent migration apply) against the target Turso database before deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)