### PR TITLE
Unify UI tokens across cards and detail pages (#78)

### DIFF
--- a/app/beans/[id]/page.tsx
+++ b/app/beans/[id]/page.tsx
@@ -89,7 +89,7 @@ export default async function BeanDetailPage({ params }: BeanDetailPageProps) {
 
         {/* Origin Info */}
         <section className="mb-6 rounded-xl bg-card p-4 shadow-sm">
-          <h2 className="mb-3 text-sm font-medium tracking-wider text-muted-foreground">
+          <h2 className="mb-2 text-sm font-medium tracking-wider text-muted-foreground">
             origin
           </h2>
           <div className="flex flex-col gap-3">
@@ -138,7 +138,7 @@ export default async function BeanDetailPage({ params }: BeanDetailPageProps) {
         {/* Brew History */}
         {brews.length > 0 && (
           <section>
-            <h2 className="mb-3 text-sm font-medium tracking-wider text-muted-foreground">
+            <h2 className="mb-2 text-sm font-medium tracking-wider text-muted-foreground">
               brew history
             </h2>
             <div className="flex flex-col gap-3">

--- a/app/beans/[id]/page.tsx
+++ b/app/beans/[id]/page.tsx
@@ -78,7 +78,7 @@ export default async function BeanDetailPage({ params }: BeanDetailPageProps) {
             </div>
             <div className="flex-1">
               <h1 className="text-xl font-semibold text-foreground">{bean.name}</h1>
-              <p className="mt-1 text-xs uppercase tracking-wide text-muted-foreground">Roastery</p>
+              <p className="mt-1 text-xs tracking-wide text-muted-foreground">roastery</p>
               <p className="text-sm text-foreground">{bean.roaster}</p>
               <div className="mt-2">
                 <RoastLevel level={bean.roast} size="sm" />
@@ -89,23 +89,23 @@ export default async function BeanDetailPage({ params }: BeanDetailPageProps) {
 
         {/* Origin Info */}
         <section className="mb-6 rounded-xl bg-card p-4 shadow-sm">
-          <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-muted-foreground">
-            Origin
+          <h2 className="mb-3 text-sm font-medium tracking-wider text-muted-foreground">
+            origin
           </h2>
           <div className="flex flex-col gap-3">
             <div className="flex items-center gap-3">
               <MapPin className="h-4 w-4 text-muted-foreground" />
               <div>
-                <p className="text-xs uppercase tracking-wide text-muted-foreground">Region</p>
+                <p className="text-xs tracking-wide text-muted-foreground">region</p>
                 <p className="text-sm font-medium text-foreground">{bean.region}</p>
-                <p className="text-xs text-muted-foreground">Country: {bean.country}</p>
+                <p className="text-xs text-muted-foreground">country: {bean.country}</p>
               </div>
             </div>
             {bean.farm && (
               <div className="flex items-center gap-3">
                 <Factory className="h-4 w-4 text-muted-foreground" />
                 <div>
-                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Producer</p>
+                  <p className="text-xs tracking-wide text-muted-foreground">producer</p>
                   <p className="text-sm text-foreground">{bean.farm}</p>
                 </div>
               </div>
@@ -113,9 +113,9 @@ export default async function BeanDetailPage({ params }: BeanDetailPageProps) {
             <div className="flex items-center gap-3">
               <Leaf className="h-4 w-4 text-muted-foreground" />
               <div className="flex flex-col gap-1">
-                <p className="text-xs uppercase tracking-wide text-muted-foreground">Variety</p>
+                <p className="text-xs tracking-wide text-muted-foreground">variety</p>
                 <span className="text-sm text-foreground">{bean.variety}</span>
-                <p className="text-xs uppercase tracking-wide text-muted-foreground">Process</p>
+                <p className="text-xs tracking-wide text-muted-foreground">process</p>
                 <span className="text-sm text-foreground">{bean.process ?? '—'}</span>
               </div>
             </div>
@@ -125,8 +125,8 @@ export default async function BeanDetailPage({ params }: BeanDetailPageProps) {
         {/* Notes */}
         {bean.notes && (
           <section className="mb-6 rounded-xl bg-card p-4 shadow-sm">
-            <h2 className="mb-2 text-sm font-medium uppercase tracking-wider text-muted-foreground">
-              Notes
+            <h2 className="mb-2 text-sm font-medium tracking-wider text-muted-foreground">
+              notes
             </h2>
             <p className="text-sm leading-relaxed text-foreground">{bean.notes}</p>
           </section>
@@ -138,8 +138,8 @@ export default async function BeanDetailPage({ params }: BeanDetailPageProps) {
         {/* Brew History */}
         {brews.length > 0 && (
           <section>
-            <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-muted-foreground">
-              Brew History
+            <h2 className="mb-3 text-sm font-medium tracking-wider text-muted-foreground">
+              brew history
             </h2>
             <div className="flex flex-col gap-3">
               {brews.map((brew) => (

--- a/app/brews/[id]/page.test.tsx
+++ b/app/brews/[id]/page.test.tsx
@@ -200,7 +200,7 @@ describe('BrewDetailPage', () => {
 
     expect(screen.getByText('-°C')).toBeDefined()
     expect(screen.queryByText(/null°C/)).toBeNull()
-    expect(screen.getByText('Temperature')).toBeDefined()
+    expect(screen.getByText('temperature')).toBeDefined()
   })
 
   // C5: beanGrind null → "-" shown in grind tile, "null" not shown, Grind (clicks) label still visible
@@ -214,7 +214,7 @@ describe('BrewDetailPage', () => {
 
     render(page)
 
-    const grindLabel = screen.getByText('Grind (clicks)')
+    const grindLabel = screen.getByText('grind (clicks)')
     const grindTile = grindLabel.parentElement
     if (!grindTile) throw new Error('Grind tile not found')
     expect(within(grindTile).getByText('-')).toBeDefined()
@@ -234,8 +234,8 @@ describe('BrewDetailPage', () => {
 
     expect(screen.getByText('-°C')).toBeDefined()
     expect(screen.queryByText(/null°C/)).toBeNull()
-    expect(screen.getByText('Temperature')).toBeDefined()
-    const grindLabel = screen.getByText('Grind (clicks)')
+    expect(screen.getByText('temperature')).toBeDefined()
+    const grindLabel = screen.getByText('grind (clicks)')
     const grindTile = grindLabel.parentElement
     if (!grindTile) throw new Error('Grind tile not found')
     expect(within(grindTile).getByText('-')).toBeDefined()

--- a/app/brews/[id]/page.tsx
+++ b/app/brews/[id]/page.tsx
@@ -83,8 +83,8 @@ export default async function BrewDetailPage({ params }: BrewDetailPageProps) {
 
         {/* Brew Parameters */}
         <section className="mb-6 rounded-xl bg-card p-4 shadow-sm">
-          <h2 className="mb-4 text-sm font-medium uppercase tracking-wider text-muted-foreground">
-            Parameters
+          <h2 className="mb-4 text-sm font-medium tracking-wider text-muted-foreground">
+            parameters
           </h2>
           <div className="grid grid-cols-2 gap-4">
             <div className="flex items-center gap-3">
@@ -93,7 +93,7 @@ export default async function BrewDetailPage({ params }: BrewDetailPageProps) {
               </div>
               <div>
                 <p className="font-mono text-lg font-medium">{brew.beanWeight}g</p>
-                <p className="text-xs text-muted-foreground">Coffee</p>
+                <p className="text-xs text-muted-foreground">coffee</p>
               </div>
             </div>
             <div className="flex items-center gap-3">
@@ -102,7 +102,7 @@ export default async function BrewDetailPage({ params }: BrewDetailPageProps) {
               </div>
               <div>
                 <p className="font-mono text-lg font-medium">{brew.waterWeight}g</p>
-                <p className="text-xs text-muted-foreground">Water</p>
+                <p className="text-xs text-muted-foreground">water</p>
               </div>
             </div>
             <div className="flex items-center gap-3">
@@ -111,7 +111,7 @@ export default async function BrewDetailPage({ params }: BrewDetailPageProps) {
               </div>
               <div>
                 <p className="font-mono text-lg font-medium">{brew.waterTemp == null ? '-' : brew.waterTemp}°C</p>
-                <p className="text-xs text-muted-foreground">Temperature</p>
+                <p className="text-xs text-muted-foreground">temperature</p>
               </div>
             </div>
             <div className="flex items-center gap-3">
@@ -120,12 +120,12 @@ export default async function BrewDetailPage({ params }: BrewDetailPageProps) {
               </div>
               <div>
                 <p className="font-mono text-lg font-medium">{brew.beanGrind == null ? '-' : brew.beanGrind}</p>
-                <p className="text-xs text-muted-foreground">Grind (clicks)</p>
+                <p className="text-xs text-muted-foreground">grind (clicks)</p>
               </div>
             </div>
           </div>
           <div className="mt-4 flex items-center justify-center rounded-lg bg-secondary p-3">
-            <span className="text-sm text-muted-foreground">Brew Ratio</span>
+            <span className="text-sm text-muted-foreground">brew ratio</span>
             <span className="ml-2 font-mono text-lg font-medium">1:{ratio}</span>
           </div>
         </section>
@@ -141,8 +141,8 @@ export default async function BrewDetailPage({ params }: BrewDetailPageProps) {
         {/* Taste Profile */}
         {brew.overall > 0 && (
           <section className="mb-6 rounded-xl bg-card p-4 shadow-sm">
-            <h2 className="mb-2 text-sm font-medium uppercase tracking-wider text-muted-foreground">
-              Taste Profile
+            <h2 className="mb-2 text-sm font-medium tracking-wider text-muted-foreground">
+              taste profile
             </h2>
             <TasteRadar
               aroma={brew.aroma}
@@ -157,8 +157,8 @@ export default async function BrewDetailPage({ params }: BrewDetailPageProps) {
         {/* Flavors */}
         {brew.flavors.length > 0 && (
           <section className="mb-6 rounded-xl bg-card p-4 shadow-sm">
-            <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-muted-foreground">
-              Flavor Notes
+            <h2 className="mb-3 text-sm font-medium tracking-wider text-muted-foreground">
+              flavor notes
             </h2>
             <div className="flex flex-wrap gap-2">
               {brew.flavors.map((flavor) => (
@@ -176,8 +176,8 @@ export default async function BrewDetailPage({ params }: BrewDetailPageProps) {
         {/* Notes */}
         {brew.notes && (
           <section className="rounded-xl bg-card p-4 shadow-sm">
-            <h2 className="mb-2 text-sm font-medium uppercase tracking-wider text-muted-foreground">
-              Tasting Notes
+            <h2 className="mb-2 text-sm font-medium tracking-wider text-muted-foreground">
+              tasting notes
             </h2>
             <p className="text-sm leading-relaxed text-foreground">{brew.notes}</p>
           </section>

--- a/app/brews/[id]/page.tsx
+++ b/app/brews/[id]/page.tsx
@@ -83,7 +83,7 @@ export default async function BrewDetailPage({ params }: BrewDetailPageProps) {
 
         {/* Brew Parameters */}
         <section className="mb-6 rounded-xl bg-card p-4 shadow-sm">
-          <h2 className="mb-4 text-sm font-medium tracking-wider text-muted-foreground">
+          <h2 className="mb-2 text-sm font-medium tracking-wider text-muted-foreground">
             parameters
           </h2>
           <div className="grid grid-cols-2 gap-4">
@@ -157,7 +157,7 @@ export default async function BrewDetailPage({ params }: BrewDetailPageProps) {
         {/* Flavors */}
         {brew.flavors.length > 0 && (
           <section className="mb-6 rounded-xl bg-card p-4 shadow-sm">
-            <h2 className="mb-3 text-sm font-medium tracking-wider text-muted-foreground">
+            <h2 className="mb-2 text-sm font-medium tracking-wider text-muted-foreground">
               flavor notes
             </h2>
             <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## 概要

Issue #78「各種ページやコンポーネントの UI を共通化し見た目の統一感を出す」を解消する純粋な見た目調整。詳細ページの `<h2>` セクション見出しから `uppercase` を除去してソースリテラルを lowercase に揃え、データフィールドラベル（roastery / temperature / grind (clicks) など）を lowercase に統一。さらに 7 箇所の `<h2>` の `mb-*` を `mb-2` に統一して垂直リズムを揃えた。CRUD・API・バリデーションは無変更。

## 受け入れ基準

- [x] `app/beans/[id]/page.tsx` の `<h2>` 3 件 (`origin`/`notes`/`brew history`) と `app/brews/[id]/page.tsx` の `<h2>` 4 件 (`parameters`/`taste profile`/`flavor notes`/`tasting notes`) すべてで `uppercase` ユーティリティを除去、リテラルを lowercase に
- [x] データフィールドラベル lowercase 化: `roastery`, `region`, `country`, `producer`, `variety`, `process`, `coffee`, `water`, `temperature`, `grind (clicks)`, `brew ratio`
- [x] 全 7 箇所の `<h2>` className が同一値 `"mb-2 text-sm font-medium tracking-wider text-muted-foreground"` に統一
- [x] `bean-card.tsx` / `brew-card.tsx` は uppercase 固定ラベル不在のため変更不要
- [x] テスト assert を lowercase に追従更新: `app/brews/[id]/page.test.tsx` で `Temperature`/`Grind (clicks)` を lowercase に
- [x] `pnpm exec tsc --noEmit` 0 エラー、`pnpm test -- --run` 243 passed / 0 failed
- [x] CRUD・API・バリデーション・null フォールバックは無変更（純粋な見た目調整）

## 範囲外

- ロゴ・カラーテーマの刷新
- ダークモード切替の追加
- 新規 UI コンポーネントの導入
- レスポンシブブレイクポイントの新設
- PWA 化、フォントの差し替え

## Trinity 実行サマリ

- Run: `.trinity/20260503T113842Z-issue-78-ui-unification`
- Iterations: 2/15
- Final verdict: PASS
- Final commit: `2246781`

## 判定根拠

PASS

検証チェーン（Evaluator 独立再実行）:

- `pnpm exec tsc --noEmit` exit 0
- `pnpm test -- --run` 243 passed / 0 failed (23 files)
- `pnpm lint` N/A（eslint バイナリ未インストール）

Iteration 1 で唯一指摘された `<h2>` の `mb-*` プレフィックス混在（mb-2/mb-3/mb-4 の 3 値）は Iteration 2 で全 7 箇所を `mb-2` に統一して完全解消。uppercase 残存ゼロ・ラベル lowercase 化・font-mono hero rating・section `p-4`・null フォールバック・既存 243 テスト assert はすべて維持。

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Trinity pipeline