### PR TITLE
抽出タイマーのリセット確認ダイアログ

### DIFF
--- a/components/brew-timer.test.tsx
+++ b/components/brew-timer.test.tsx
@@ -157,8 +157,8 @@ describe('BrewTimer', () => {
     expect(onStop).toHaveBeenCalledTimes(1)
   })
 
-  // Click wiring — stopped
-  it('click wiring: clicking Reset in stopped state calls onReset', () => {
+  // Click wiring — stopped (新仕様: Reset 押下では onReset を呼ばず確認ダイアログを開く)
+  it('click wiring: clicking Reset in stopped state does NOT call onReset and shows confirm dialog', () => {
     const onReset = vi.fn()
     const noop = vi.fn()
     render(
@@ -173,7 +173,48 @@ describe('BrewTimer', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Reset' }))
+    expect(onReset).not.toHaveBeenCalled()
+    expect(screen.getByText('リセットすると抽出ステップがクリアされます。続行しますか？')).toBeDefined()
+  })
+
+  // Confirm dialog — Confirm calls onReset exactly once
+  it('confirm dialog: clicking Confirm (リセット) calls onReset exactly once', () => {
+    const onReset = vi.fn()
+    const noop = vi.fn()
+    render(
+      <BrewTimer
+        status="stopped"
+        elapsed={10000}
+        onStart={noop}
+        onLap={noop}
+        onStop={noop}
+        onReset={onReset}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset' }))
+    fireEvent.click(screen.getByRole('button', { name: 'リセット' }))
     expect(onReset).toHaveBeenCalledTimes(1)
+  })
+
+  // Confirm dialog — Cancel does not call onReset
+  it('confirm dialog: clicking Cancel (キャンセル) does not call onReset', () => {
+    const onReset = vi.fn()
+    const noop = vi.fn()
+    render(
+      <BrewTimer
+        status="stopped"
+        elapsed={10000}
+        onStart={noop}
+        onLap={noop}
+        onStop={noop}
+        onReset={onReset}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset' }))
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }))
+    expect(onReset).not.toHaveBeenCalled()
   })
 
   // T_buttons_full_width: each button gets flex-1 so buttons fill the available row width

--- a/components/brew-timer.tsx
+++ b/components/brew-timer.tsx
@@ -2,6 +2,17 @@
 
 import type { ReactElement } from 'react'
 import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
 import { Flag, Play, RotateCcw, Square } from 'lucide-react'
 import type { BrewTimerStatus } from '@/hooks/use-brew-timer'
 
@@ -68,10 +79,26 @@ export function BrewTimer({
           </>
         )}
         {status === 'stopped' && (
-          <Button type="button" variant="outline" className="flex-1" onClick={onReset}>
-            <RotateCcw aria-hidden className="mr-2 h-4 w-4" />
-            Reset
-          </Button>
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button type="button" variant="outline" className="flex-1">
+                <RotateCcw aria-hidden className="mr-2 h-4 w-4" />
+                Reset
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>タイマーをリセット</AlertDialogTitle>
+                <AlertDialogDescription>
+                  リセットすると抽出ステップがクリアされます。続行しますか？
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                <AlertDialogAction onClick={onReset}>リセット</AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         )}
       </div>
     </div>


### PR DESCRIPTION
## 概要

抽出タイマー（BrewTimer）の Reset ボタンは、押下するとタイマー状態のみならず将来的に紐づく抽出ステップ（new-brew-form 側で扱う行データ）も合わせて初期化される破壊的操作である。現在は確認ステップを挟まずに `onReset` が即時に発火するため、誤タップでラップ済みの抽出記録を失うリスクがある。issue #98 はこのリスクを回避するため、Reset 押下時に「リセットすると抽出ステップがクリアされます。続行しますか？」という確認ダイアログを挟むことを求めている。本変更は BrewTimer の内部にだけ確認ダイアログを差し込み、`onReset` の呼び出しタイミングを「ユーザーが Confirm を押した瞬間」に限定する。

なお現状 BrewTimer は `components/new-brew-form.tsx` から取り外されており、UI 上で Reset ボタンが露出していない（PR #78 / commit `e259e4e`）。それでも BrewTimer 単体としての契約は将来の再統合時に効いてくるため、コンポーネント単体で Reset の安全性を担保する。

Closes #98

## 受け入れ基準

- 機能性: `status === 'stopped'` で Reset ボタンを押した瞬間には `onReset` が呼ばれず、確認ダイアログが開く。
- 機能性: ダイアログの Confirm（`AlertDialogAction`）を押すと `onReset` がちょうど 1 回呼ばれる。
- 機能性: ダイアログの Cancel（`AlertDialogCancel`）を押した場合、または ESC / オーバーレイクリック等で閉じた場合、`onReset` は呼ばれない。
- コピー: ダイアログ本文に「リセットすると抽出ステップがクリアされます。続行しますか？」が表示される。
- コピー: Confirm ボタンのラベルは「リセット」、Cancel ボタンのラベルは「キャンセル」。
- コピー: ダイアログにはタイトル「タイマーをリセット」が `AlertDialogTitle` として置かれる。
- 非破壊: `status === 'idle'` / `'running'` 時のレンダリング（Start / Lap / Stop 配置）に変化がなく、既存テストが現行のまま PASS する。
- 非破壊: `status === 'stopped'` 時に Reset ボタン（`role="button"`, name "Reset"）が引き続き存在し、`flex-1` クラスを保持する。
- 既存契約: `BrewTimerProps` が変わらない（props 追加・改名・削除をしない）。
- コード品質: 新規 import は `@/components/ui/alert-dialog` の必要なエクスポート分のみ。`components/brew-timer.tsx` 以外のソースは変更しない（テストファイルは除く）。
- コード品質: `useBrewTimer` と `new-brew-form.tsx` には一切手を加えない。
- テスト: `components/brew-timer.test.tsx` に 3 ケース（Reset で onReset が呼ばれずダイアログが出る / Confirm で 1 回呼ばれる / Cancel で呼ばれない）が追加され、いずれも PASS する。
- グリーン: `pnpm test`、ESLint、`tsc --noEmit` がすべてパスする。

## Trinity 実行サマリ

- Run: .trinity/20260506T061549Z-issue-98-reset-confirm-dialog
- Iterations: 1/15
- Final verdict: PASS
- Final commit: 4017e13

## 判定根拠（最終 Evaluator レポートからの抜粋）

Verdict: PASS

- typecheck: PASS — `pnpm exec tsc --noEmit` 出力なし・終了コード 0
- lint: PASS（変更 2 ファイル対象、エラー 0 件）
- unit: PASS — `pnpm exec vitest run` 348 passed / 38 files; brew-timer.test.tsx 単体 11/11 PASS
- 受け入れ基準: 全項目で根拠を確認済み（path:line 付き）
  - Reset ボタンが `AlertDialogTrigger asChild` に包まれ即時発火を排除（`components/brew-timer.tsx:82-101`）
  - 仕様文字列（タイトル / 本文 / Confirm / Cancel）と完全一致（`brew-timer.tsx:91-98`）
  - `BrewTimerProps` 無変更（`brew-timer.tsx:19-26`）
  - `git diff HEAD~1 HEAD --name-only` は `components/brew-timer.tsx`, `components/brew-timer.test.tsx` の 2 ファイルのみ
- 持ち越し指摘: なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)