### PR TITLE
PR #100 follow-up: ログアウト導線・抽出フォーム保存・Add bean 注釈削除・価格入力フォーマット

### DIFF
--- a/app/beans/[id]/page.test.tsx
+++ b/app/beans/[id]/page.test.tsx
@@ -18,6 +18,14 @@ vi.mock('@/lib/auth/require-user', () => ({
   requireUser: requireUserMock,
 }))
 
+vi.mock('@/lib/auth/actions', () => ({
+  signOutAction: vi.fn(),
+}))
+
+vi.mock('@/components/user-menu', () => ({
+  UserMenu: () => <div data-testid="user-menu" />,
+}))
+
 vi.mock('@/app/beans/service', () => ({
   beansService: {
     getBeanById: getBeanByIdMock,

--- a/app/beans/[id]/page.tsx
+++ b/app/beans/[id]/page.tsx
@@ -2,11 +2,13 @@ import { notFound } from 'next/navigation'
 import { beansService } from '@/app/beans/service'
 import { brewsService } from '@/app/brews/service'
 import { requireUser } from '@/lib/auth/require-user'
+import { signOutAction } from '@/lib/auth/actions'
 import { COUNTRY_FLAGS } from '@/lib/types'
 import { ROAST_COLORS } from '@/lib/roast-colors'
 import { BrewCard } from '@/components/brew-card'
 import { DeleteResourceButton } from '@/components/delete-resource-button'
 import { PageHeader, HeaderAction } from '@/components/page-header'
+import { UserMenu } from '@/components/user-menu'
 import { SectionHeading } from '@/components/section-heading'
 import { Card } from '@/components/ui/card'
 import { DataField } from '@/components/data-field'
@@ -71,6 +73,7 @@ export default async function BeanDetailPage({ params }: BeanDetailPageProps) {
             >
               <Plus className="h-4 w-4" />
             </HeaderAction>
+            <UserMenu email={user.email} name={user.name} signOutAction={signOutAction} />
           </>
         }
       />

--- a/app/brews/[id]/page.test.tsx
+++ b/app/brews/[id]/page.test.tsx
@@ -16,6 +16,14 @@ vi.mock('@/lib/auth/require-user', () => ({
   requireUser: requireUserMock,
 }))
 
+vi.mock('@/lib/auth/actions', () => ({
+  signOutAction: vi.fn(),
+}))
+
+vi.mock('@/components/user-menu', () => ({
+  UserMenu: () => <div data-testid="user-menu" />,
+}))
+
 vi.mock('@/app/brews/service', () => ({
   brewsService: {
     getBrewById: getBrewByIdMock,

--- a/app/brews/[id]/page.tsx
+++ b/app/brews/[id]/page.tsx
@@ -2,11 +2,13 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { brewsService } from '@/app/brews/service'
 import { requireUser } from '@/lib/auth/require-user'
+import { signOutAction } from '@/lib/auth/actions'
 import { COUNTRY_FLAGS } from '@/lib/types'
 import { TasteBars } from '@/components/taste-bars'
 import { PourChart } from '@/components/pour-chart'
 import { DeleteResourceButton } from '@/components/delete-resource-button'
 import { PageHeader, HeaderAction } from '@/components/page-header'
+import { UserMenu } from '@/components/user-menu'
 import { SectionHeading } from '@/components/section-heading'
 import { Card } from '@/components/ui/card'
 import { FlavorBadge } from '@/components/flavor-badge'
@@ -66,6 +68,7 @@ export default async function BrewDetailPage({ params }: BrewDetailPageProps) {
               showLabel={false}
               className="h-8 w-8 px-0"
             />
+            <UserMenu email={user.email} name={user.name} signOutAction={signOutAction} />
           </>
         }
       />

--- a/app/new/page.tsx
+++ b/app/new/page.tsx
@@ -2,10 +2,12 @@ import { Suspense } from 'react'
 import { ArrowLeft } from 'lucide-react'
 import { NewEntryTabs } from '@/components/new-entry-tabs'
 import { PageHeader, HeaderAction } from '@/components/page-header'
+import { UserMenu } from '@/components/user-menu'
 import { beansService } from '@/app/beans/service'
 import { flavorsService } from '@/app/flavors/service'
 import { brewsService } from '@/app/brews/service'
 import { requireUser } from '@/lib/auth/require-user'
+import { signOutAction } from '@/lib/auth/actions'
 
 export const dynamic = 'force-dynamic'
 
@@ -39,6 +41,7 @@ export default async function NewPage({ searchParams }: NewPageProps) {
             <span className="font-medium">New Entry</span>
           </>
         }
+        actions={<UserMenu email={user.email} name={user.name} signOutAction={signOutAction} />}
       />
 
       <main className="mx-auto max-w-md px-4 py-6">

--- a/app/page.render.test.tsx
+++ b/app/page.render.test.tsx
@@ -39,6 +39,18 @@ vi.mock('lucide-react', () => ({
   Coffee: () => null,
   Flame: () => null,
   BookMarked: () => null,
+  LogOut: () => null,
+  User: () => null,
+}))
+
+// auth アクションをモック
+vi.mock('@/lib/auth/actions', () => ({
+  signOutAction: vi.fn(),
+}))
+
+// UserMenu をモック
+vi.mock('@/components/user-menu', () => ({
+  UserMenu: () => <div data-testid="user-menu" />,
 }))
 
 // next/link をモック

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import { beansService } from '@/app/beans/service'
 import { brewsService } from '@/app/brews/service'
 import { requireUser } from '@/lib/auth/require-user'
+import { signOutAction } from '@/lib/auth/actions'
 import { StatsCard } from '@/components/stats-card'
 import { BeanCard } from '@/components/bean-card'
 import { Greeting } from '@/components/greeting'
@@ -15,6 +16,7 @@ import {
 import { PageHeader, HeaderAction } from '@/components/page-header'
 import { SectionHeading } from '@/components/section-heading'
 import { Button } from '@/components/ui/button'
+import { UserMenu } from '@/components/user-menu'
 import { BookMarked, Coffee, Flame, Plus } from 'lucide-react'
 import Link from 'next/link'
 
@@ -45,6 +47,7 @@ export default async function HomePage() {
             <HeaderAction href="/new?type=bean" variant="primary" aria-label="Add bean">
               <Plus className="h-4 w-4" />
             </HeaderAction>
+            <UserMenu email={user.email} name={user.name} signOutAction={signOutAction} />
           </>
         }
       />

--- a/app/presets/page.test.tsx
+++ b/app/presets/page.test.tsx
@@ -10,6 +10,14 @@ vi.mock('@/lib/auth/require-user', () => ({
   requireUser: requireUserMock,
 }))
 
+vi.mock('@/lib/auth/actions', () => ({
+  signOutAction: vi.fn(),
+}))
+
+vi.mock('@/components/user-menu', () => ({
+  UserMenu: () => <div data-testid="user-menu" />,
+}))
+
 vi.mock('@/app/brew-presets/service', () => ({
   brewPresetsService: {
     getBrewPresets: getBrewPresetsMock,

--- a/app/presets/page.tsx
+++ b/app/presets/page.tsx
@@ -1,9 +1,12 @@
 import Link from 'next/link'
-import { ArrowLeft } from 'lucide-react'
+import { ArrowLeft, BookMarked } from 'lucide-react'
 import { brewPresetsService } from '@/app/brew-presets/service'
 import { requireUser } from '@/lib/auth/require-user'
+import { signOutAction } from '@/lib/auth/actions'
 import { DeleteResourceButton } from '@/components/delete-resource-button'
 import { PresetEditDialog } from '@/app/presets/preset-edit-dialog'
+import { PageHeader, HeaderAction } from '@/components/page-header'
+import { UserMenu } from '@/components/user-menu'
 import {
   Empty,
   EmptyContent,
@@ -12,7 +15,6 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from '@/components/ui/empty'
-import { BookMarked } from 'lucide-react'
 
 export const dynamic = 'force-dynamic'
 
@@ -22,20 +24,17 @@ export default async function PresetsPage() {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
-      <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur-sm">
-        <div className="mx-auto flex h-14 max-w-md items-center justify-between px-4">
-          <div className="flex items-center gap-3">
-            <Link
-              href="/"
-              className="flex h-8 w-8 items-center justify-center rounded-lg hover:bg-secondary"
-            >
+      <PageHeader
+        leading={
+          <>
+            <HeaderAction href="/" aria-label="Back to home">
               <ArrowLeft className="h-4 w-4" />
-            </Link>
+            </HeaderAction>
             <span className="font-medium">Presets</span>
-          </div>
-        </div>
-      </header>
+          </>
+        }
+        actions={<UserMenu email={user.email} name={user.name} signOutAction={signOutAction} />}
+      />
 
       <main className="mx-auto max-w-md px-4 py-6">
         {/* User presets */}

--- a/components/new-bean-form.test.tsx
+++ b/components/new-bean-form.test.tsx
@@ -576,4 +576,74 @@ describe('NewBeanForm', () => {
       expect(combobox.value).toBe('Cinnamon')
     })
   })
+
+  // ---- 価格入力フォーマットテスト (D) ----
+  // jsdom の Intl.NumberFormat が返す円記号は環境によって異なる場合があるため、
+  // 実際のフォーマッターで生成した値を期待値として使う
+  const priceFormatter = new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' })
+  const pricePlaceholder = priceFormatter.format(1500)
+
+  it('D-T1: price 入力欄のプレースホルダーが JPY フォーマット（1500 相当）である', () => {
+    render(<NewBeanForm />)
+    const priceInput = screen.getByPlaceholderText(pricePlaceholder) as HTMLInputElement
+    expect(priceInput).toBeDefined()
+  })
+
+  it('D-T2: 12000 と入力すると表示値が通貨フォーマット（12000 相当）になる', async () => {
+    const expected = priceFormatter.format(12000)
+    render(<NewBeanForm />)
+    const priceInput = screen.getByPlaceholderText(pricePlaceholder) as HTMLInputElement
+    fireEvent.change(priceInput, { target: { value: '12000' } })
+    await waitFor(() => {
+      expect(priceInput.value).toBe(expected)
+    })
+  })
+
+  it('D-T3: 12000 と入力してフォームを送信すると priceJpy が整数 12000 で送られる', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: async () => ({ id: 'bean-1' }),
+      ok: true,
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<NewBeanForm />)
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Bean' } })
+    fireEvent.change(screen.getByLabelText('Roaster'), { target: { value: 'Test Roaster' } })
+    const comboboxes = screen.getAllByRole('combobox')
+    fireEvent.change(comboboxes[0], { target: { value: 'Ethiopia' } })
+    fireEvent.change(screen.getByPlaceholderText(pricePlaceholder), { target: { value: '12000' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Bean' }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    const [, requestInit] = fetchMock.mock.calls[0]
+    const body = JSON.parse((requestInit as RequestInit).body as string) as { priceJpy: number | null }
+    expect(body.priceJpy).toBe(12000)
+  })
+
+  it('D-T4: price 入力欄が空のままフォームを送信すると priceJpy が null で送られる', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: async () => ({ id: 'bean-1' }),
+      ok: true,
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<NewBeanForm />)
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Bean' } })
+    fireEvent.change(screen.getByLabelText('Roaster'), { target: { value: 'Test Roaster' } })
+    const comboboxes = screen.getAllByRole('combobox')
+    fireEvent.change(comboboxes[0], { target: { value: 'Ethiopia' } })
+    // price は空のまま送信
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Bean' }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    const [, requestInit] = fetchMock.mock.calls[0]
+    const body = JSON.parse((requestInit as RequestInit).body as string) as { priceJpy: number | null }
+    expect(body.priceJpy).toBeNull()
+  })
 })

--- a/components/new-bean-form.tsx
+++ b/components/new-bean-form.tsx
@@ -26,6 +26,8 @@ import { Field, FieldLabel } from '@/components/ui/field'
 import { SectionHeading } from '@/components/section-heading'
 
 const NO_PROCESS_VALUE = '__none__'
+const priceFormatter = new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' })
+const pricePlaceholder = priceFormatter.format(1500)
 
 interface NewBeanFormProps {
   mode?: 'create' | 'edit'
@@ -39,9 +41,30 @@ export function NewBeanForm({ mode = 'create', initialBean }: NewBeanFormProps) 
   const [roastIndex, setRoastIndex] = useState([initialRoastIndex])
   const [name, setName] = useState(initialBean?.name ?? '')
   const [roaster, setRoaster] = useState(initialBean?.roaster ?? '')
-  const [priceJpy, setPriceJpy] = useState<string>(
+  // priceRaw は整数文字列（送信用）、priceDisplay はフォーマット済み文字列（表示用）
+  const [priceRaw, setPriceRaw] = useState<string>(
     initialBean?.priceJpy != null ? String(initialBean.priceJpy) : '',
   )
+
+  function formatPriceDisplay(raw: string): string {
+    if (raw === '') return ''
+    const num = parseInt(raw, 10)
+    if (isNaN(num)) return raw
+    return priceFormatter.format(num)
+  }
+
+  const [priceDisplay, setPriceDisplay] = useState<string>(
+    initialBean?.priceJpy != null
+      ? formatPriceDisplay(String(initialBean.priceJpy))
+      : '',
+  )
+
+  function handlePriceChange(input: string) {
+    // 数字以外を除去して整数値を得る
+    const digits = input.replace(/[^\d]/g, '')
+    setPriceRaw(digits)
+    setPriceDisplay(digits === '' ? '' : formatPriceDisplay(digits))
+  }
   const [country, setCountry] = useState<(typeof COUNTRIES)[number] | ''>(initialBean?.country ?? '')
   const [region, setRegion] = useState(initialBean?.region ?? '')
   const [farm, setFarm] = useState(initialBean?.farm ?? '')
@@ -73,7 +96,7 @@ export function NewBeanForm({ mode = 'create', initialBean }: NewBeanFormProps) 
           variety,
           process,
           roast: ROAST_LEVELS[roastIndex[0]],
-          priceJpy: priceJpy === '' ? null : Number(priceJpy),
+          priceJpy: priceRaw === '' ? null : Number(priceRaw),
           notes,
         }),
       })
@@ -127,13 +150,11 @@ export function NewBeanForm({ mode = 'create', initialBean }: NewBeanFormProps) 
             <FieldLabel htmlFor="priceJpy">Price (JPY)</FieldLabel>
             <Input
               id="priceJpy"
-              type="number"
+              type="text"
               inputMode="numeric"
-              min="0"
-              step="1"
-              placeholder="1500"
-              value={priceJpy}
-              onChange={(event) => setPriceJpy(event.target.value)}
+              placeholder={pricePlaceholder}
+              value={priceDisplay}
+              onChange={(event) => handlePriceChange(event.target.value)}
             />
           </Field>
         </div>

--- a/components/new-brew-form.tsx
+++ b/components/new-brew-form.tsx
@@ -243,6 +243,10 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
 
   const handleSaveAsPreset = async () => {
     if (!presetName.trim()) return
+    if (steps.length === 0) {
+      toast({ title: 'Add at least one step before saving as preset', variant: 'destructive' })
+      return
+    }
     setIsSavingPreset(true)
     try {
       const response = await fetch('/api/brew-presets', {
@@ -700,7 +704,6 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
           type="button"
           variant="outline"
           className="w-full"
-          disabled={steps.length === 0}
           onClick={() => setIsSaveDialogOpen(true)}
         >
           Save current as preset

--- a/components/new-entry-tabs.tsx
+++ b/components/new-entry-tabs.tsx
@@ -69,12 +69,7 @@ export function NewEntryTabs({ beans, flavors, initialBean: initialBeanData, ini
           Add Bean
         </button>
       </div>
-      {!hasBeans && (
-        <p className="mb-6 rounded-xl border border-dashed bg-card px-4 py-3 text-sm text-muted-foreground">
-          Add a bean first. Brew logging is enabled after at least one bean exists in the
-          database.
-        </p>
-      )}
+
 
       {/* Forms */}
       {activeTab === 'brew' ? (

--- a/components/user-menu.test.tsx
+++ b/components/user-menu.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * UserMenu コンポーネントテスト
+ *
+ * - トリガー（イニシャルボタン）が表示される
+ * - サインアウトのフォームが存在する（Server Action 経由）
+ */
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { UserMenu } from '@/components/user-menu'
+
+// DropdownMenu の Radix UI ポータルが jsdom で動作しないためモックする
+vi.mock('@/components/ui/dropdown-menu', () => {
+  const React = require('react')
+
+  function DropdownMenu({ children }: { children: React.ReactNode }) {
+    return <>{children}</>
+  }
+
+  function DropdownMenuTrigger({ children, asChild }: { children: React.ReactNode; asChild?: boolean }) {
+    if (asChild) {
+      return <>{children}</>
+    }
+    return <div>{children}</div>
+  }
+
+  function DropdownMenuContent({ children }: { children: React.ReactNode }) {
+    return <div role="menu">{children}</div>
+  }
+
+  function DropdownMenuItem({ children, asChild }: { children: React.ReactNode; asChild?: boolean }) {
+    if (asChild) {
+      return <>{children}</>
+    }
+    return <div role="menuitem">{children}</div>
+  }
+
+  function DropdownMenuSeparator() {
+    return <hr />
+  }
+
+  return {
+    DropdownMenu,
+    DropdownMenuTrigger,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+  }
+})
+
+const signOutMock = vi.fn().mockResolvedValue(undefined)
+
+describe('UserMenu', () => {
+  it('メールの先頭文字をイニシャルとして表示するボタンがある', () => {
+    render(
+      <UserMenu email="test@example.com" name={null} signOutAction={signOutMock} />
+    )
+    const trigger = screen.getByRole('button', { name: 'User menu' })
+    expect(trigger).toBeDefined()
+    expect(trigger.textContent).toBe('T')
+  })
+
+  it('name がある場合は name の先頭文字をイニシャルとして表示する', () => {
+    render(
+      <UserMenu email="test@example.com" name="Alice" signOutAction={signOutMock} />
+    )
+    const trigger = screen.getByRole('button', { name: 'User menu' })
+    expect(trigger.textContent).toBe('A')
+  })
+
+  it('メールアドレスがメニュー内に表示される', () => {
+    render(
+      <UserMenu email="test@example.com" name={null} signOutAction={signOutMock} />
+    )
+    expect(screen.getByText('test@example.com')).toBeDefined()
+  })
+
+  it('Sign out ボタンが存在する', () => {
+    render(
+      <UserMenu email="test@example.com" name={null} signOutAction={signOutMock} />
+    )
+    const signOutBtn = screen.getByRole('button', { name: /sign out/i })
+    expect(signOutBtn).toBeDefined()
+  })
+})

--- a/components/user-menu.tsx
+++ b/components/user-menu.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { LogOut, User } from 'lucide-react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+
+interface UserMenuProps {
+  email: string
+  name: string | null
+  signOutAction: () => Promise<void>
+}
+
+export function UserMenu({ email, name, signOutAction }: UserMenuProps) {
+  const initial = (name?.[0] ?? email[0]).toUpperCase()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label="User menu"
+          className="flex h-8 w-8 items-center justify-center rounded-lg bg-secondary text-sm font-medium text-foreground hover:bg-secondary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {initial}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-48">
+        <div className="flex items-center gap-2 px-2 py-1.5">
+          <User className="h-4 w-4 text-muted-foreground" />
+          <span className="truncate text-xs text-muted-foreground">{email}</span>
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <form action={signOutAction}>
+            <button
+              type="submit"
+              className="flex w-full cursor-default items-center gap-2 text-sm"
+            >
+              <LogOut className="h-4 w-4" />
+              Sign out
+            </button>
+          </form>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/lib/auth/actions.ts
+++ b/lib/auth/actions.ts
@@ -1,0 +1,7 @@
+'use server'
+
+import { signOut } from '@/lib/auth'
+
+export async function signOutAction() {
+  await signOut({ redirectTo: '/login' })
+}


### PR DESCRIPTION
## 概要

PR #100 (`trinity/20260506T061658Z-bundle-pr83-pr89-pr93`) に対する作者本人 (yjn279) の最新レビュー 4 件をすべて 1 PR で消化する。具体的にはログアウト導線がそもそも存在しない、抽出フォームの「保存ボタンが見当たらない」、Add bean 画面の不要な注釈、価格入力欄の表示フォーマットの 4 つで、いずれも UI 表層の追従修正に閉じる。サーバー API・スキーマ・マイグレーションには手を入れない。

base はあえて `trinity/20260506T061658Z-bundle-pr83-pr89-pr93` (= PR #100 のヘッド) に向けてある。本 PR をマージすれば PR #100 のブランチが追従し、PR #100 のレビュー指摘がそのまま解消する。

## 受け入れ基準

### 機能

- [x] ログイン状態でアプリのいずれの認証必須ページ（少なくとも `/`, `/new`, `/beans/[id]`, `/brews/[id]`, `/presets`）を開いても、ヘッダー右上にユーザーを示すトリガー要素が表示される。
- [x] そのトリガーをクリック / タップすると DropdownMenu が開き、「Sign out」の項目が出る。
- [x] 「Sign out」を選択すると `signOut` 経由でセッションが破棄され、最終的に `/login` に遷移する。
- [x] `/login` ページ自身にはユーザーメニューが出ない。
- [x] 抽出フォームに「現在の入力をプリセットとして保存」できる UI がユーザーが見える状態で常時置かれている（`steps` 0 件時は submit 時にトーストで弾く）。
- [x] その UI を操作して `name` を入力し保存すると、同画面の「Insert preset」DropdownMenu に新しいプリセットがリロードなしで現れる。
- [x] 保存リクエストは既存の `POST /api/brew-presets` を使う。新エンドポイントは作られていない。
- [x] `/new?type=bean` に「Add a bean first. Brew logging is enabled after at least one bean exists in the database.」という文字列が一切表示されない。
- [x] bean の create / edit フォームの price 入力欄のプレースホルダーが `¥1,500` 形式である。
- [x] 同じ入力欄でユーザーが連続した数字を入力すると、画面上は `¥12,000` のように 3 桁カンマ区切り + `¥` で表示される。
- [x] そのまま submit すると `priceJpy` が整数値で送られる（カンマ・`¥` を含む文字列ではない）。
- [x] 入力欄を空のまま submit したときは `priceJpy: null` が送られる。

### 品質ゲート

- [x] `pnpm exec tsc --noEmit` exit 0
- [x] `pnpm test -- --run` 472 passed / 0 failed (54 test files、既存比 +4 件)
- [x] `pnpm build` exit 0

### 影響範囲

- [x] 変更は `app/` / `components/` / `lib/auth/` に閉じる
- [x] `drizzle/`, `lib/db/`, `app/api/`, `middleware.ts` は無変更

## Trinity 実行サマリ

- Run: `.trinity/20260506T143138Z-pr100-review-comments`
- Iterations: 1/15
- Final verdict: PASS
- Final commit: `ecf7432`

## 判定根拠（最終 Evaluator レポートからの抜粋）

PASS

すべての受け入れ基準が PASS。品質ゲート（tsc / test / build）いずれも exit 0 で通過。変更は `app/`, `components/`, `lib/auth/` に完全に閉じており、スコープ外ファイル（drizzle, lib/db, app/api, middleware.ts）への変更は一切ない。計画の 4 項目（A: ユーザーメニュー / B: プリセット保存ボタン常時表示 / C: 注釈削除 / D: 価格フォーマット）が正しく実装されており、テストカバレッジも適切に追加されている。

主要な根拠ファイル:
- `lib/auth/actions.ts:5-6` `signOutAction` Server Action
- `components/user-menu.tsx:22-51` DropdownMenu + Sign out
- `app/page.tsx:50` / `app/new/page.tsx:44` / `app/beans/[id]/page.tsx:76` / `app/brews/[id]/page.tsx:71` / `app/presets/page.tsx:36` の `<UserMenu>` 配置
- `components/new-brew-form.tsx:703` の `disabled` 削除 + `:246-248` の steps=0 トースト
- `components/new-entry-tabs.tsx` で「Add a bean first」削除（grep 0 件）
- `components/new-bean-form.tsx:153-157` の `type=text` + `inputMode=numeric` + `pricePlaceholder` + `priceDisplay` / `priceRaw` 分離