### PR TITLE
chore: ignore .vercel directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ node_modules
 .next/
 .DS_Store
 *.tsbuildinfo
+.vercel


### PR DESCRIPTION
## 概要

`vercel link` を実行すると Vercel CLI が `.vercel/` ディレクトリを生成する（プロジェクトIDなどリンク情報）。これはローカル固有でリポジトリにコミットすべきでないため `.gitignore` に追加する。

## 変更

- `.gitignore` に `.vercel` の1行を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)