### PR TITLE
プリセットの保存ボタン/ダイアログを Extraction Steps ヘッダに統合する

### DIFF
--- a/components/new-brew-form.test.tsx
+++ b/components/new-brew-form.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NewBrewForm } from '@/components/new-brew-form'
 import type { Bean, BrewWithBean, Flavor } from '@/lib/types'
@@ -1191,8 +1191,8 @@ describe('NewBrewForm', () => {
     expect(step1Water.value).toBe('50')
   })
 
-  // P4: "Save as preset" button exists; clicking it opens a dialog; submitting calls POST /api/brew-presets
-  it('P4: given valid step inputs, when "Save current as preset" is clicked and name is entered, then POST /api/brew-presets is called with the correct body', async () => {
+  // P4: "Save preset" button in Extraction Steps header opens a dialog; submitting calls POST /api/brew-presets
+  it('P4: given valid step inputs, when "Save preset" header button is clicked and name is entered, then POST /api/brew-presets is called with the correct body', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve([]),
@@ -1209,20 +1209,21 @@ describe('NewBrewForm', () => {
     fireEvent.change(screen.getByLabelText('Step 1 water'), { target: { value: '50' } })
     fireEvent.blur(screen.getByLabelText('Step 1 water'))
 
-    // Click "Save current as preset"
-    const saveButton = screen.getByRole('button', { name: /save.*preset/i })
+    // Click "Save preset" button in Extraction Steps header
+    const saveButton = screen.getByRole('button', { name: 'Save preset' })
     expect(saveButton).toBeDefined()
     fireEvent.click(saveButton)
 
     // Dialog should open
-    expect(screen.getByRole('dialog')).toBeDefined()
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toBeDefined()
 
     // Enter preset name
     const nameInput = screen.getByLabelText('Name') as HTMLInputElement
     fireEvent.change(nameInput, { target: { value: 'My New Preset' } })
 
     // Click Save Preset button in dialog
-    const savePresetButton = screen.getByRole('button', { name: /Save Preset/i })
+    const savePresetButton = within(dialog).getByRole('button', { name: /Save Preset/i })
     fireEvent.click(savePresetButton)
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1236,5 +1237,16 @@ describe('NewBrewForm', () => {
     const postBody = JSON.parse((postCall[1] as RequestInit).body as string) as { name: string; steps: Array<{ time: number; water: number }> }
     expect(postBody.name).toBe('My New Preset')
     expect(postBody.steps.length).toBeGreaterThan(0)
+  })
+
+  // P5: フォーム末尾に独立した「Save as Preset」セクションが存在しないことを確認
+  it('P5: the standalone "Save as Preset" section is not rendered at the bottom of the form', () => {
+    render(<NewBrewForm beans={beans} flavors={flavors} />)
+
+    // 「Save current as preset」というラベルのボタンは存在しない
+    expect(screen.queryByRole('button', { name: /save current as preset/i })).toBeNull()
+    // 「Save as Preset」という見出し（h2）はフォーム末尾に存在しない
+    const headings = screen.queryAllByRole('heading', { name: /save as preset/i })
+    expect(headings.length).toBe(0)
   })
 })

--- a/components/new-brew-form.tsx
+++ b/components/new-brew-form.tsx
@@ -17,7 +17,7 @@ import {
 import type { Bean, BrewWithBean, Flavor } from '@/lib/types'
 import { COUNTRY_FLAGS } from '@/lib/types'
 import { DEFAULT_RATINGS, STEP_TIME_INTERVAL, STEP_WATER_INTERVAL } from '@/lib/constants'
-import { ChevronDown, Loader2, Plus, X } from 'lucide-react'
+import { BookmarkPlus, ChevronDown, Loader2, Plus, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Switch } from '@/components/ui/switch'
 import { Card } from '@/components/ui/card'
@@ -420,6 +420,18 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
       <Card>
         <div className="mb-3 flex items-center justify-between">
           <SectionHeading className="mb-0">Extraction Steps</SectionHeading>
+          <div className="flex items-center gap-1">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1 px-2 text-xs"
+              aria-label="Save preset"
+              onClick={() => setIsSaveDialogOpen(true)}
+            >
+              <BookmarkPlus className="h-3 w-3" />
+              Save
+            </Button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -455,6 +467,7 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
               )}
             </DropdownMenuContent>
           </DropdownMenu>
+          </div>
         </div>
 
         <div className="mb-4">
@@ -629,21 +642,6 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
           onChange={(event) => setNotes(event.target.value)}
         />
       </Card>
-
-      {/* Save as preset */}
-      <div className="rounded-xl bg-card p-4 shadow-sm">
-        <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-muted-foreground">
-          Save as Preset
-        </h2>
-        <Button
-          type="button"
-          variant="outline"
-          className="w-full"
-          onClick={() => setIsSaveDialogOpen(true)}
-        >
-          Save current as preset
-        </Button>
-      </div>
 
       {/* Submit */}
       <Button type="submit" size="lg" className="w-full" disabled={isSubmitting}>


### PR DESCRIPTION
## 概要

- Extraction Steps カード冒頭ヘッダ (`components/new-brew-form.tsx:421-458`) で、「Insert preset」ボタンの**左**に隣接する Save トリガボタンを追加する。
- そのボタンを押下するとプリセット名（必須）と Description（任意）を入力できる既存ダイアログ (`components/new-brew-form.tsx:660-708`) が開き、現状のフォーム状態（`steps`, `beanWeight`, `waterTemp`）を含めて `POST /api/brew-presets` で保存される。
- フォーム下部の独立セクション「Save as Preset」(`components/new-brew-form.tsx:633-646`) は削除し、Extraction Steps ヘッダの新ボタンに保存導線を一本化する。
- 「Insert preset」ボタンの既存挙動・aria-label・ドロップダウン中身は変更しない（issue 由来のスコープ外）。

## 受け入れ基準

- [x] 機能性: Extraction Steps カード冒頭ヘッダに、Insert preset ボタンの**左**側に隣接する Save トリガボタン（`aria-label="Save preset"` または同等の Save を示すアクセシブルネーム）が存在する。Insert preset ボタンの aria-label は引き続き `"Insert preset"` のまま。
- [x] 機能性: 新 Save ボタンを押下すると `<DialogTitle>Save as Preset</DialogTitle>` のダイアログが開き、`Name` ラベル付き入力と `Description (optional)` ラベル付きテキストエリアが表示される。
- [x] 機能性: ダイアログで Name に文字列を入力し `Save Preset` ボタンを押下すると、`POST /api/brew-presets` が呼ばれ、リクエストボディに `name` と `steps`（length > 0）が含まれる（既存テスト P4 と同等の検証）。
- [x] 機能性: フォーム末尾（Tasting Notes と Submit ボタンの間）の独立した「Save as Preset」見出しと「Save current as preset」ボタンは DOM 上に存在しない。
- [x] 機能性: 既存の Insert preset ドロップダウン（`aria-label="Insert preset"`、配下の `userPresets` メニュー、`No saved presets yet` の空状態）は引き続き機能し、選択時に `applyPreset` が呼ばれる挙動が維持されている（既存テスト P1〜P3 がパスする）。
- [x] コード品質: `components/new-brew-form.tsx` 内に新規の `any` 型を追加しない。`handleSaveAsPreset`, `isSaveDialogOpen`, `presetName`, `presetDescription`, `isSavingPreset` の宣言は再利用し重複定義しない。
- [x] コード品質: 新 Save ボタンに `type="button"` が付与されており、フォーム submit を発火させない。
- [x] ビジュアル設計: 新 Save ボタンの大きさ・余白は Insert preset ボタンと視覚的に揃う（同程度の高さ、ヘッダ右端の操作グループ内で適切に gap が取られている）。
- [x] ビジュアル設計: Extraction Steps ヘッダは横スクロールやはみ出しを起こさない（モバイル幅 375px で見出しと 2 つのボタンが 1 行に収まる）。
- [x] 製品としての厚み: ダイアログを開いた直後、Name が空のときは `Save Preset` ボタンが disabled、Name 入力後は enabled に切り替わる。
- [x] 製品としての厚み: `steps.length === 0` 状態で保存を試みた場合、既存の toast ガード挙動が引き続き機能する。
- [x] 既存テスト: `components/new-brew-form.test.tsx` の P1, P2, P3 はそのままパスする。
- [x] 既存テスト: P4 は新トリガに合わせて更新済み。

## Trinity 実行サマリ

- Run: .trinity/20260508T164557Z-preset-save-dialog
- Iterations: 1/15
- Final verdict: PASS
- Final commit: eadc843

## 判定根拠（最終 Evaluator レポートからの抜粋）

判定: **PASS**

軸別スコア:
- 機能性: PASS — Save ボタンがヘッダ右端の `flex` 操作グループ内で DOM 順 Save→Insert preset として配置 (`components/new-brew-form.tsx:423-470`)。独立セクション削除、ダイアログ開閉、POST パスはすべてテストで実証済み。
- コード品質: PASS — `type="button"` (`components/new-brew-form.tsx:425`)、新規 `any` 型なし、state 重複なし、`BookmarkPlus` のみインポート追加 (`components/new-brew-form.tsx:20`)。
- ビジュアル設計: PASS — `h-7 gap-1 px-2 text-xs` + `variant="outline"` + `size="sm"` が Insert preset ボタンと完全一致 (`components/new-brew-form.tsx:426-428` vs `components/new-brew-form.tsx:439-441`)。
- 製品としての厚み: PASS — `disabled={!presetName.trim() || isSavingPreset}` (`components/new-brew-form.tsx:696`) と `steps.length === 0` ガード (`components/new-brew-form.tsx:235-238`) はいずれも変更なく機能維持。

検証チェーン: typecheck PASS、unit 33 pass / 0 fail、lint は worktree の既存設定問題で SKIP（本コミット起因ではない）。

Closes #105