### PR TITLE
プリセット保存ダイアログの "(optional)" 表記と保存ボタンアイコンの削除

### DIFF
--- a/components/new-brew-form.test.tsx
+++ b/components/new-brew-form.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NewBrewForm } from '@/components/new-brew-form'
 import type { Bean, BrewWithBean, Flavor } from '@/lib/types'
@@ -1191,8 +1191,8 @@ describe('NewBrewForm', () => {
     expect(step1Water.value).toBe('50')
   })
 
-  // P4: "Save as preset" button exists; clicking it opens a dialog; submitting calls POST /api/brew-presets
-  it('P4: given valid step inputs, when "Save current as preset" is clicked and name is entered, then POST /api/brew-presets is called with the correct body', async () => {
+  // P4: "Save preset" button in Extraction Steps header opens a dialog; submitting calls POST /api/brew-presets
+  it('P4: given valid step inputs, when "Save preset" header button is clicked and name is entered, then POST /api/brew-presets is called with the correct body', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve([]),
@@ -1209,20 +1209,21 @@ describe('NewBrewForm', () => {
     fireEvent.change(screen.getByLabelText('Step 1 water'), { target: { value: '50' } })
     fireEvent.blur(screen.getByLabelText('Step 1 water'))
 
-    // Click "Save current as preset"
-    const saveButton = screen.getByRole('button', { name: /save.*preset/i })
+    // Click "Save preset" button in Extraction Steps header
+    const saveButton = screen.getByRole('button', { name: 'Save preset' })
     expect(saveButton).toBeDefined()
     fireEvent.click(saveButton)
 
     // Dialog should open
-    expect(screen.getByRole('dialog')).toBeDefined()
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toBeDefined()
 
     // Enter preset name
     const nameInput = screen.getByLabelText('Name') as HTMLInputElement
     fireEvent.change(nameInput, { target: { value: 'My New Preset' } })
 
     // Click Save Preset button in dialog
-    const savePresetButton = screen.getByRole('button', { name: /Save Preset/i })
+    const savePresetButton = within(dialog).getByRole('button', { name: /Save Preset/i })
     fireEvent.click(savePresetButton)
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1236,5 +1237,16 @@ describe('NewBrewForm', () => {
     const postBody = JSON.parse((postCall[1] as RequestInit).body as string) as { name: string; steps: Array<{ time: number; water: number }> }
     expect(postBody.name).toBe('My New Preset')
     expect(postBody.steps.length).toBeGreaterThan(0)
+  })
+
+  // P5: フォーム末尾に独立した「Save as Preset」セクションが存在しないことを確認
+  it('P5: the standalone "Save as Preset" section is not rendered at the bottom of the form', () => {
+    render(<NewBrewForm beans={beans} flavors={flavors} />)
+
+    // 「Save current as preset」というラベルのボタンは存在しない
+    expect(screen.queryByRole('button', { name: /save current as preset/i })).toBeNull()
+    // 「Save as Preset」という見出し（h2）はフォーム末尾に存在しない
+    const headings = screen.queryAllByRole('heading', { name: /save as preset/i })
+    expect(headings.length).toBe(0)
   })
 })

--- a/components/new-brew-form.tsx
+++ b/components/new-brew-form.tsx
@@ -17,7 +17,7 @@ import {
 import type { Bean, BrewWithBean, Flavor } from '@/lib/types'
 import { COUNTRY_FLAGS } from '@/lib/types'
 import { DEFAULT_RATINGS, STEP_TIME_INTERVAL, STEP_WATER_INTERVAL } from '@/lib/constants'
-import { BookmarkPlus, ChevronDown, Loader2, Plus, X } from 'lucide-react'
+import { ChevronDown, Loader2, Plus, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Switch } from '@/components/ui/switch'
 import { Card } from '@/components/ui/card'
@@ -429,7 +429,6 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
               aria-label="Save preset"
               onClick={() => setIsSaveDialogOpen(true)}
             >
-              <BookmarkPlus className="h-3 w-3" />
               Save
             </Button>
           <DropdownMenu>

--- a/components/new-brew-form.tsx
+++ b/components/new-brew-form.tsx
@@ -17,7 +17,7 @@ import {
 import type { Bean, BrewWithBean, Flavor } from '@/lib/types'
 import { COUNTRY_FLAGS } from '@/lib/types'
 import { DEFAULT_RATINGS, STEP_TIME_INTERVAL, STEP_WATER_INTERVAL } from '@/lib/constants'
-import { ChevronDown, Loader2, Plus, X } from 'lucide-react'
+import { BookmarkPlus, ChevronDown, Loader2, Plus, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Switch } from '@/components/ui/switch'
 import { Card } from '@/components/ui/card'
@@ -420,6 +420,18 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
       <Card>
         <div className="mb-3 flex items-center justify-between">
           <SectionHeading className="mb-0">Extraction Steps</SectionHeading>
+          <div className="flex items-center gap-1">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1 px-2 text-xs"
+              aria-label="Save preset"
+              onClick={() => setIsSaveDialogOpen(true)}
+            >
+              <BookmarkPlus className="h-3 w-3" />
+              Save
+            </Button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -455,6 +467,7 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
               )}
             </DropdownMenuContent>
           </DropdownMenu>
+          </div>
         </div>
 
         <div className="mb-4">
@@ -629,21 +642,6 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
           onChange={(event) => setNotes(event.target.value)}
         />
       </Card>
-
-      {/* Save as preset */}
-      <div className="rounded-xl bg-card p-4 shadow-sm">
-        <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-muted-foreground">
-          Save as Preset
-        </h2>
-        <Button
-          type="button"
-          variant="outline"
-          className="w-full"
-          onClick={() => setIsSaveDialogOpen(true)}
-        >
-          Save current as preset
-        </Button>
-      </div>
 
       {/* Submit */}
       <Button type="submit" size="lg" className="w-full" disabled={isSubmitting}>

--- a/components/new-brew-form.tsx
+++ b/components/new-brew-form.tsx
@@ -674,7 +674,7 @@ export function NewBrewForm({ mode = "create", initialBeanId, initialBrew, beans
               />
             </div>
             <div className="flex flex-col gap-1.5">
-              <Label htmlFor="preset-description">Description (optional)</Label>
+              <Label htmlFor="preset-description">Description</Label>
               <Textarea
                 id="preset-description"
                 placeholder="Describe this preset..."


### PR DESCRIPTION
## 概要

- \`eadc843\`（feat(preset): integrate Save preset button into Extraction Steps header）を本 worktree のブランチへマージし、Extraction Steps カードヘッダの Insert preset ボタン左隣に \`aria-label=\"Save preset\"\` のボタンが存在する状態を作る。
- マージ後の Save preset ボタンから \`<BookmarkPlus className=\"h-3 w-3\" />\` を削除し、ボタン子要素をテキスト \`Save\` のみにする。\`lucide-react\` import からも \`BookmarkPlus\` を取り除く。
- イテレーション 1 で適用済みの「ダイアログ Description ラベルから \`(optional)\` を削除」（\`components/new-brew-form.tsx:677\`）はそのまま維持する。
- 上記いずれの変更も、保存ダイアログを開く / 保存 API を呼ぶ / Insert preset と並ぶレイアウトといった既存の振る舞いを壊さない。\`eadc843\` で更新済みのテスト群（P4 を \`aria-label='Save preset'\` 起点に変更、P5 で末尾セクション非存在を検証）はそのままパスし続ける。

## 受け入れ基準

- マージ済み: \`git log\` で \`eadc843\`（または同等のコンテンツ）が本イテレーションのコミット系列に含まれており、\`components/new-brew-form.tsx\` の Extraction Steps カードヘッダに \`aria-label=\"Save preset\"\` のボタン要素が存在する。
- 機能性: Save as Preset ダイアログを開いたとき、Description フィールドの可視ラベルが厳密に \`Description\` であり、\`(optional)\`、\`（任意）\` 等の補足表記を含まない。
- 機能性: ダイアログの Name 入力 → Save Preset 押下 → \`POST /api/brew-presets\` が呼ばれる既存フロー（P4 テスト）が引き続きパスする。
- 機能性: Extraction Steps カードヘッダの \`aria-label=\"Save preset\"\` ボタンを押下すると Save as Preset ダイアログが開く。Insert preset ボタンの挙動・ラベル・\`ChevronDown\` アイコンは変化しない。
- 機能性: Save preset ボタンの DOM 子要素に \`svg\` / \`lucide-*\` クラス / アイコンコンポーネントが一切存在しない。可視テキスト \`Save\` のみがレンダリングされる。
- 機能性: フォーム末尾に独立した \"Save as Preset\" セクションが存在しない（P5 テストがパスし続ける）。
- コード品質: \`components/new-brew-form.tsx\` の \`lucide-react\` import から \`BookmarkPlus\` が削除されている。新規 \`any\` 型は追加されていない。
- コード品質: \`npx tsc --noEmit\` を \`components/new-brew-form.tsx\` 起因のエラーなしでパスする。
- ビジュアル設計: Extraction Steps ヘッダ右側操作群が「Save（テキストのみ）」「Insert preset（テキスト + ChevronDown）」の順で横並びになり、両ボタンの高さが揃う。
- ビジュアル設計: ダイアログ内 Name と Description のラベルは同一 \`<Label>\` スタイルで揃っており、文言だけが \`Name\` / \`Description\` の 2 つになっている。
- 既存テスト: \`npx vitest run components/new-brew-form.test.tsx\` が全パスする（P1〜P5 を含む）。失敗 0 件。
- スコープ規律: \`app/presets/preset-edit-dialog.tsx\` 等のスコープ外ファイルに変更がない。

## Trinity 実行サマリ

- Run: \`.trinity/20260508T171157Z-remove-optional-save-icon\`
- Iterations: 2/15
- Final verdict: PASS
- Final commit: ca4cc68

## 判定根拠（最終 Evaluator レポートからの抜粋）

判定: PASS

軸別スコア:
- 機能性: PASS — \`aria-label=\"Save preset\"\` ボタンが \`components/new-brew-form.tsx:429\` に存在し、子要素がテキスト \`Save\` のみ（\`components/new-brew-form.tsx:432\`）。\`(optional)\` 文字列なし（Grep ヒットなし）。P4・P5 テストを含む 33 テストが全パス。
- コード品質: PASS — \`components/new-brew-form.tsx:20\` の lucide-react import に \`BookmarkPlus\` が存在しない。tsc エラーセットは既存のみ。
- ビジュアル設計: PASS — \`components/new-brew-form.tsx:423-445\` でヘッダ右側の 2 ボタンが同スタイルで横並び。ダイアログラベルが \`Name\` / \`Description\` の 2 つのみ。
- 製品としての厚み: PASS — フォーム末尾の独立 Save セクションが削除済み（P5 パス）。ダイアログの placeholder・必須制約・開閉ロジックは無変更。既存テスト 33 件全パスでリグレッションなし。