### PR TITLE
メールマジックリンク認証の廃止（Google OAuth のみに統一）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,3 @@ AUTH_GOOGLE_SECRET=             # Google Cloud Console の OAuth クライアン
 # Preview 環境用: `https://brewia.vercel.app/api/auth` を入れると Redirect Proxy が有効になる。
 # Production と local では未設定で OK。
 AUTH_REDIRECT_PROXY_URL=
-
-# Email Magic Link プロバイダ (Resend を使用)
-AUTH_RESEND_KEY=                # Resend API キー
-EMAIL_FROM=noreply@example.com  # 送信元メールアドレス

--- a/app/login/page.render.test.tsx
+++ b/app/login/page.render.test.tsx
@@ -42,15 +42,13 @@ describe('LoginPage', () => {
     ).toBeTruthy()
   })
 
-  it('LP2: 未認証状態でレンダリングしたとき Email 入力フィールドが存在する', async () => {
+  it('LP2: 未認証状態でレンダリングしたとき Email 入力フィールドが存在しない', async () => {
     authMock.mockResolvedValue(null)
 
     render(await LoginPage())
 
-    expect(
-      screen.getByRole('textbox') ||
-      screen.getByPlaceholderText(/email/i)
-    ).toBeTruthy()
+    expect(screen.queryByRole('textbox')).toBeNull()
+    expect(screen.queryByPlaceholderText(/email/i)).toBeNull()
   })
 
   it('LP3: 認証済み状態でレンダリングしたとき redirect("/") が呼ばれる', async () => {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -16,12 +16,6 @@ export default async function LoginPage() {
     await signIn('google')
   }
 
-  async function handleEmailSignIn(formData: FormData) {
-    'use server'
-    const email = formData.get('email') as string
-    await signIn('resend', { email, redirectTo: '/' })
-  }
-
   return (
     <div className="flex min-h-screen items-center justify-center bg-background px-4">
       <div className="w-full max-w-sm space-y-8">
@@ -65,39 +59,6 @@ export default async function LoginPage() {
           </button>
         </form>
 
-        {/* Divider */}
-        <div className="relative">
-          <div className="absolute inset-0 flex items-center">
-            <span className="w-full border-t border-border" />
-          </div>
-          <div className="relative flex justify-center text-xs uppercase">
-            <span className="bg-background px-2 text-muted-foreground">Or continue with email</span>
-          </div>
-        </div>
-
-        {/* Email Magic Link */}
-        <form action={handleEmailSignIn} className="space-y-4">
-          <div className="space-y-2">
-            <label htmlFor="email" className="text-sm font-medium text-foreground">
-              Email address
-            </label>
-            <input
-              id="email"
-              name="email"
-              type="email"
-              autoComplete="email"
-              required
-              placeholder="you@example.com"
-              className="flex h-10 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-            />
-          </div>
-          <button
-            type="submit"
-            className="flex w-full items-center justify-center rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-          >
-            Send magic link
-          </button>
-        </form>
       </div>
     </div>
   )

--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -1,7 +1,6 @@
 import NextAuth from 'next-auth'
 import { DrizzleAdapter } from '@auth/drizzle-adapter'
 import Google from 'next-auth/providers/google'
-import Resend from 'next-auth/providers/resend'
 import { db } from '@/lib/db/drizzle'
 import {
   usersTable,
@@ -23,10 +22,6 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
     Google({
       clientId: process.env.AUTH_GOOGLE_ID,
       clientSecret: process.env.AUTH_GOOGLE_SECRET,
-    }),
-    Resend({
-      apiKey: process.env.AUTH_RESEND_KEY,
-      from: process.env.EMAIL_FROM ?? 'noreply@example.com',
     }),
   ],
   session: {


### PR DESCRIPTION
## 概要

GitHub Issue #107「メアドによる登録機能を削除する。」を受け、本リポジトリ唯一の「メールアドレスによる登録」手段である Resend ベースのメールマジックリンク (`next-auth/providers/resend`) を完全に取り除く。伝統的なパスワード認証（CredentialsProvider）はそもそも実装されていないため、削除対象は Resend プロバイダのみ。

### ゴール
- ログイン UI 上にメールアドレス入力フォームと「Send magic link」ボタンを表示しない
- `lib/auth/config.ts` の `providers` 配列が Google プロバイダのみで構成され、Resend プロバイダおよびその import が存在しない
- `.env.example` から Resend 関連の環境変数 (`AUTH_RESEND_KEY`, `EMAIL_FROM`) と Resend 説明コメントが除かれる
- ログインページのレンダリングテストが、メールフォームの非存在と Google サインインボタンの存在を検証する
- `pnpm test` / `tsc` 相当が緑

### 非ゴール
- DB スキーマの破壊的変更（`verificationTokensTable` 定義および drizzle マイグレーションは温存）
- バックフィル処理および `signIn` イベントハンドラの変更
- ドキュメント (`docs/auth-architecture.md`, `docs/auth-test-plan.md`) の改訂

## 受け入れ基準

機能性
- [x] `app/login/page.tsx` をレンダリングした結果に、`type=\"email\"` の input 要素および `name=\"email\"` の form 要素が一切含まれない
- [x] `app/login/page.tsx` をレンダリングした結果に「Send magic link」「Or continue with email」「Email address」のいずれの文字列も含まれない
- [x] `app/login/page.tsx` 内に `signIn('resend'` の呼び出しが存在しない
- [x] Google サインインボタン（`Sign in with Google` を含む submit ボタン）が存在する
- [x] 認証済みセッションで `LoginPage` を呼ぶと `redirect('/')` が呼ばれる挙動が維持されている

コード品質
- [x] `lib/auth/config.ts` に `Resend` の import 文が存在しない
- [x] `providers` 配列要素が Google ひとつのみで構文が壊れていない
- [x] `auth/handlers/signIn/signOut` のエクスポート、`adapter`／`session`／`callbacks`／`events.signIn` の各設定は変更されていない
- [x] `lib/db/schema.ts` の `verificationTokensTable` 定義が変更されていない
- [x] `drizzle/` 配下のマイグレーション SQL とスナップショット JSON が変更されていない
- [x] worktree 全体で `'resend'` 文字列リテラル、および `next-auth/providers/resend` の import が grep でヒットしない（docs 除く）

製品としての厚み
- [x] `.env.example` から Resend 関連の3行（コメント1 + 変数2）が削除され、その他の環境変数行は残っている
- [x] `package.json` の `dependencies` に `resend` キーが存在しない

テスト
- [x] `app/login/page.render.test.tsx` の `LP2` が「Email 入力フィールドが存在しない」ことを検証するアサーションに置き換わっている
- [x] `LP1`（Google ボタン存在）と `LP3`（認証済みなら redirect(\"/\")）が維持され、いずれもパスする
- [x] `pnpm test` がフルで緑（54 files / 473 tests passed）
- [x] `tsc --noEmit` 相当が緑

## Trinity 実行サマリ
- Run: `.trinity/20260509T133554Z-remove-email-registration`
- Iterations: 1/15
- Final verdict: PASS
- Final commit: c40aaea

## 判定根拠（最終 Evaluator レポートからの抜粋）

- 機能性: PASS — email form/input/action が page.tsx から完全削除。Google ボタンと redirect(\"/\") は維持。`app/login/page.tsx:9-17,31-60`
- コード品質: PASS — Resend import と providers エントリが config.ts から除去、他設定不変。worktree 全体に `resend` 残存なし。`lib/auth/config.ts:1-45`
- ビジュアル設計: PASS — 既存 Tailwind トークン継続使用、任意色なし、max-w-sm / space-y-8 維持。`app/login/page.tsx:20-21,34`
- 製品としての厚み: PASS — .env.example 3行削除・他環境変数行維持。schema.ts / drizzle マイグレーション変更なし。package.json に resend なし。

検証チェーン:
- `pnpm exec tsc --noEmit`: PASS（出力なし、終了コード 0）
- `pnpm test --run`: PASS（54 files / 473 tests、失敗 0）
- lint: N/A（eslint バイナリ未インストールは pre-existing 状態）