### PR TITLE
メールアドレス登録機能（Email Magic Link / Resend）の撤去

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,3 @@ AUTH_GOOGLE_SECRET=             # Google Cloud Console の OAuth クライアン
 # Preview 環境用: `https://brewia.vercel.app/api/auth` を入れると Redirect Proxy が有効になる。
 # Production と local では未設定で OK。
 AUTH_REDIRECT_PROXY_URL=
-
-# Email Magic Link プロバイダ (Resend を使用)
-AUTH_RESEND_KEY=                # Resend API キー
-EMAIL_FROM=noreply@example.com  # 送信元メールアドレス

--- a/app/login/page.render.test.tsx
+++ b/app/login/page.render.test.tsx
@@ -42,15 +42,13 @@ describe('LoginPage', () => {
     ).toBeTruthy()
   })
 
-  it('LP2: 未認証状態でレンダリングしたとき Email 入力フィールドが存在する', async () => {
+  it('LP2: 未認証状態でレンダリングしたとき Email 入力フィールドが存在しない', async () => {
     authMock.mockResolvedValue(null)
 
     render(await LoginPage())
 
-    expect(
-      screen.getByRole('textbox') ||
-      screen.getByPlaceholderText(/email/i)
-    ).toBeTruthy()
+    expect(screen.queryByRole('textbox')).toBeNull()
+    expect(screen.queryByPlaceholderText(/email/i)).toBeNull()
   })
 
   it('LP3: 認証済み状態でレンダリングしたとき redirect("/") が呼ばれる', async () => {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -16,12 +16,6 @@ export default async function LoginPage() {
     await signIn('google')
   }
 
-  async function handleEmailSignIn(formData: FormData) {
-    'use server'
-    const email = formData.get('email') as string
-    await signIn('resend', { email, redirectTo: '/' })
-  }
-
   return (
     <div className="flex min-h-screen items-center justify-center bg-background px-4">
       <div className="w-full max-w-sm space-y-8">
@@ -62,40 +56,6 @@ export default async function LoginPage() {
               />
             </svg>
             Sign in with Google
-          </button>
-        </form>
-
-        {/* Divider */}
-        <div className="relative">
-          <div className="absolute inset-0 flex items-center">
-            <span className="w-full border-t border-border" />
-          </div>
-          <div className="relative flex justify-center text-xs uppercase">
-            <span className="bg-background px-2 text-muted-foreground">Or continue with email</span>
-          </div>
-        </div>
-
-        {/* Email Magic Link */}
-        <form action={handleEmailSignIn} className="space-y-4">
-          <div className="space-y-2">
-            <label htmlFor="email" className="text-sm font-medium text-foreground">
-              Email address
-            </label>
-            <input
-              id="email"
-              name="email"
-              type="email"
-              autoComplete="email"
-              required
-              placeholder="you@example.com"
-              className="flex h-10 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-            />
-          </div>
-          <button
-            type="submit"
-            className="flex w-full items-center justify-center rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-          >
-            Send magic link
           </button>
         </form>
       </div>

--- a/docs/auth-architecture.md
+++ b/docs/auth-architecture.md
@@ -8,7 +8,7 @@
 
 ### Goals
 
-- Auth.js (NextAuth v5 beta) + Google OAuth + Email Magic Link によるログイン/ログアウト
+- Auth.js (NextAuth v5 beta) + Google OAuth によるログイン/ログアウト
 - ユーザーセッションを Turso（libSQL/SQLite）に永続化
 - `bean` / `brew` をユーザー単位にスコープし、他ユーザーのデータに一切アクセスできないよう保護
 - 既存データの喪失なし（最初のログインユーザーが既存データを引き取る backfill）
@@ -28,7 +28,7 @@
 ## 2. 合意済みの方針（再掲）
 
 1. **認証プロバイダ**: Auth.js (NextAuth v5 beta / `next-auth@5`) + Drizzle Adapter (`@auth/drizzle-adapter`)。user/account/session/verificationToken テーブルを Turso に相乗り。
-2. **ログイン手段**: Google OAuth + Email Magic Link（実装時は Resend を想定、インターフェースは抽象化）。
+2. **ログイン手段**: Google OAuth のみ（Email Magic Link / Resend は Issue #107 で廃止済み）。
 3. **既存データ移行**: 最初にログインしたユーザーが既存の全 bean/brew/brew_flavor を引き取る backfill SQL。データ喪失は避ける。
 4. **`flavor` は共有マスタ**: `user_id` を付けない。全ユーザーで共有。
 5. **未認証ゲート**: `/login` と `/api/auth/*` 以外はすべてログイン必須。未認証は `/login` にリダイレクト。
@@ -417,7 +417,7 @@ app/layout.tsx
   セッションプロバイダ不要（Auth.js v5 は RSC ネイティブ）
 
 .env.example
-  AUTH_SECRET, AUTH_GOOGLE_ID, AUTH_GOOGLE_SECRET, AUTH_RESEND_KEY, EMAIL_FROM 追加
+  AUTH_SECRET, AUTH_GOOGLE_ID, AUTH_GOOGLE_SECRET 追加（AUTH_RESEND_KEY / EMAIL_FROM は Issue #107 で削除済み）
 
 drizzle/
   0001_add_auth_tables.sql        # Auth.js 4テーブル追加
@@ -463,8 +463,8 @@ export const config = {
 
 - Server Component。`requireUser()` は呼ばない（ログインページ自体は公開）。
 - セッションがある場合は `/` にリダイレクト（`auth()` を呼んで確認）。
-- Google ログインボタンと Email Magic Link フォームを表示。
-- `signIn('google')` / `signIn('resend', { email })` を Server Action または Client Component から呼び出す。
+- Google ログインボタンのみを表示（Email Magic Link フォームは Issue #107 で廃止済み）。
+- `signIn('google')` を Server Action から呼び出す。
 
 ---
 
@@ -535,10 +535,10 @@ SQLite は `ALTER COLUMN` をサポートしないため、テーブル再作成
 
 ### スライス 1: Auth.js 基盤
 
-**目的**: Google OAuth + Email Magic Link でのログイン/ログアウトが動作する。セッションが Turso に保存される。
+**目的**: Google OAuth でのログイン/ログアウトが動作する。セッションが Turso に保存される。（Email Magic Link / Resend は Issue #107 で廃止済み）
 
 **対象ファイル**:
-- `package.json` に `next-auth@5`, `@auth/drizzle-adapter`, `resend` 追加
+- `package.json` に `next-auth@5`, `@auth/drizzle-adapter` 追加
 - `lib/db/schema.ts` に Auth.js 4テーブル追加
 - `lib/auth/config.ts`, `lib/auth/require-user.ts`, `lib/auth/index.ts`
 - `app/api/auth/[...nextauth]/route.ts`
@@ -549,7 +549,6 @@ SQLite は `ALTER COLUMN` をサポートしないため、テーブル再作成
 **受け入れ条件**:
 - `/` にアクセス → 未ログインなら `/login` にリダイレクト
 - Google ログイン → `/` に戻る
-- Email Magic Link → メールが届きクリックで `/` に戻る
 - ログアウト → `/login` に戻る
 - Turso DB に session/user/account 行が作成される
 - `/offline`, `/login`, `/api/auth/*` は未認証でアクセス可能
@@ -729,10 +728,6 @@ AUTH_SECRET=                    # openssl rand -base64 32 で生成。必須。
 AUTH_GOOGLE_ID=                 # Google Cloud Console の OAuth クライアント ID
 AUTH_GOOGLE_SECRET=             # Google Cloud Console の OAuth クライアントシークレット
 
-# Email Magic Link プロバイダ (Resend を想定)
-AUTH_RESEND_KEY=                # Resend API キー
-EMAIL_FROM=noreply@example.com  # 送信元メールアドレス
-
 # 既存（参考）
 TURSO_DATABASE_URL=
 TURSO_AUTH_TOKEN=
@@ -762,7 +757,7 @@ ANTHROPIC_API_KEY=
 
 ### 11.3 `app/login/page.tsx` のデザイン
 
-最低限の機能（Google ボタン + Email フォーム）でよいか、ブランドロゴや説明文のデザインが必要かを確認。
+Google ボタンのみの最小ログイン画面として実装済み（Issue #107 で Email フォームを廃止）。
 
 ### 11.4 `flavor` の管理
 

--- a/docs/auth-test-plan.md
+++ b/docs/auth-test-plan.md
@@ -19,7 +19,7 @@
 ### スコープ外
 
 - **Slice 6 (NOT NULL 化)**: 別 PR に切り出す。このテスト計画ではスコープ外。テスト除外項目一覧（セクション 5）に記載。
-- 実 OAuth フロー / 実メール送信（Resend）
+- 実 OAuth フロー（Email Magic Link / Resend は Issue #107 で廃止済み）
 - Drizzle Adapter の実 DB 動作確認
 - PWA オフライン時の認証挙動
 - マイグレーション SQL ファイルの内容検証
@@ -258,10 +258,10 @@ describe('LoginPage', () => {
   // Act: render(<LoginPage />)
   // Assert: screen.getByRole('button', { name: /Google/ }) または getByText(/Google/) が存在する
 
-  it('LP2: 未認証状態でレンダリングしたとき Email 入力フィールドが存在する')
+  it('LP2: 未認証状態でレンダリングしたとき Email 入力フィールドが存在しない（廃止済み: Issue #107）')
   // Arrange: authMock.mockResolvedValue(null)
   // Act: render(<LoginPage />)
-  // Assert: screen.getByRole('textbox', { name: /email/i }) または getByPlaceholderText(/email/i) が存在する
+  // Assert: screen.queryByRole('textbox') が null、screen.queryByPlaceholderText(/email/i) が null
 
   it('LP3: 認証済み状態でレンダリングしたとき redirect("/") が呼ばれる')
   // Arrange: authMock.mockResolvedValue({ user: { id: 'user-1', email: 'a@example.com' } })
@@ -276,8 +276,8 @@ describe('LoginPage', () => {
 2. `lib/auth/require-user.ts` を実装して green にする（`auth()` 呼び出しと null ガード + redirect のみ）。
 3. `middleware.test.ts` の M1〜M8 を書く（`middleware.ts` が存在しないので red）。
 4. `middleware.ts` を実装して green にする。
-5. `app/login/page.render.test.tsx` の LP1〜LP2 を書く（`app/login/page.tsx` が存在しないので red）。
-6. `app/login/page.tsx` を最小実装（ボタンと input フィールドのみ）して green にする。
+5. `app/login/page.render.test.tsx` の LP1〜LP3 を書く（`app/login/page.tsx` が存在しないので red）。
+6. `app/login/page.tsx` を最小実装（Google ボタンのみ）して green にする。
 
 #### 3.1.5 受け入れ条件との対応
 
@@ -289,13 +289,12 @@ describe('LoginPage', () => {
 | `requireUser()` 認証済み → user 返却 | RU1, RU4 |
 | `getAuthenticatedUser()` 未認証 → null | GAU2, GAU3 |
 | Google ログインボタンが存在 | LP1 |
-| Email Magic Link フォームが存在 | LP2 |
+| Email 入力フィールドが存在しない（Issue #107 で廃止） | LP2 |
 | ログイン済みで /login → / へリダイレクト | LP3 |
 
 #### 3.1.6 除外項目
 
 - 実 Google OAuth コールバックフロー（E2E レベル、手動確認）
-- 実 Resend メール送信（手動確認）
 - Drizzle Adapter による session/user/account テーブルへの書き込み確認（手動確認）
 - `lib/auth/config.ts` の providers/adapter 設定内容のテスト（Auth.js 内部実装に依存するため）
 
@@ -956,7 +955,7 @@ describe('DELETE /api/brews/[id]', () => {
 | S1 | `requireUser()` セッションなし → redirect('/login') | RU2, RU3 |
 | S1 | `getAuthenticatedUser()` セッションなし → null | GAU2, GAU3 |
 | S1 | ログインページに Google ボタンが存在 | LP1 |
-| S1 | ログインページに Email フォームが存在 | LP2 |
+| S1 | ログインページに Email 入力フィールドが存在しない（Issue #107 で廃止） | LP2 |
 | S1 | ログイン済みで `/login` → `/` リダイレクト | LP3 |
 | S2 | 1人目サインイン → NULL 行がそのユーザーに割り当てられる | BF1, BF2, BF3 |
 | S2 | 2回実行しても結果が変わらない（冪等） | BF4 |
@@ -993,7 +992,7 @@ describe('DELETE /api/brews/[id]', () => {
 | 除外項目 | 理由 | 確認方法 |
 |---|---|---|
 | 実 Google OAuth フロー | 外部サービス依存・E2E レベル | 手動確認（Vercel プレビュー環境） |
-| 実 Resend メール送信 | 外部サービス依存 | 手動確認（実メール受信） |
+| 実 Resend メール送信 | Issue #107 で廃止済み | 対応不要 |
 | Drizzle Adapter の session/user/account 書き込み | Auth.js 内部実装に依存 | 手動確認（DB 直接 SELECT） |
 | `lib/auth/config.ts` の providers/adapter 設定 | Auth.js v5 beta の API に依存 | 手動確認 + 型チェック |
 | マイグレーション SQL ファイルの内容検証 | SQL テスト環境が未整備 | 手動実行 + `SELECT COUNT(*)` 確認 |

--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -1,7 +1,6 @@
 import NextAuth from 'next-auth'
 import { DrizzleAdapter } from '@auth/drizzle-adapter'
 import Google from 'next-auth/providers/google'
-import Resend from 'next-auth/providers/resend'
 import { db } from '@/lib/db/drizzle'
 import {
   usersTable,
@@ -23,10 +22,6 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
     Google({
       clientId: process.env.AUTH_GOOGLE_ID,
       clientSecret: process.env.AUTH_GOOGLE_SECRET,
-    }),
-    Resend({
-      apiKey: process.env.AUTH_RESEND_KEY,
-      from: process.env.EMAIL_FROM ?? 'noreply@example.com',
     }),
   ],
   session: {


### PR DESCRIPTION
## 概要

ログイン手段としての「メールアドレスによる登録 / サインイン（Resend を用いた Email Magic Link）」を撤去し、Brewia の認証手段を Google OAuth のみに集約する。`app/login/page.tsx` の Email フォーム、`lib/auth/config.ts` の Resend プロバイダ、`.env.example` の関連環境変数、関連ドキュメントの記述、対応するレンダリングテストを整合性を取って削除・更新する。Auth.js Drizzle Adapter に渡している `verificationTokensTable` 定義と DB マイグレーションファイルは将来の OTP 等への拡張余地として残置する。Issue #107（https://github.com/yjn279/brewia/issues/107）の対応。

## 受け入れ基準

### 機能性

- [x] `app/login/page.tsx` に `handleEmailSignIn` 関数が存在しない（テキスト検索で 0 件）。
- [x] `app/login/page.tsx` に `type="email"` の `<input>`、`name="email"` の input、または "Send magic link" 文言、"Or continue with email" 文言のいずれもが存在しない。
- [x] `app/login/page.tsx` の Google サインインボタンと `handleGoogleSignIn` server action および認証済み時の `redirect('/')` 動作は保持されている。
- [x] `lib/auth/config.ts` 内に `from 'next-auth/providers/resend'` の import 文が存在しない。
- [x] `lib/auth/config.ts` の `providers` 配列に `Resend(` を呼び出す要素が存在しない。
- [x] `lib/auth/config.ts` の `auth`, `handlers`, `signIn`, `signOut` の export は維持されている。
- [x] `.env.example` に `AUTH_RESEND_KEY` の行が存在しない。
- [x] `.env.example` に `EMAIL_FROM` の行が存在しない。
- [x] `.env.example` の Auth.js セクション（`AUTH_SECRET`, `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`, `AUTH_REDIRECT_PROXY_URL`）の行は保持されている。

### コード品質

- [x] `app/login/page.tsx` および `lib/auth/config.ts` で未使用の import が残っていない（lint で検出可能）。
- [x] 新規 `any` 型を導入していない。
- [x] `lib/db/schema.ts` の `verificationTokensTable` 定義は変更されていない。

### テスト

- [x] `app/login/page.render.test.tsx` の LP2 が、Email 入力フィールドの「非存在」を検証するテストに置き換わっている。
- [x] LP1（Google ボタン存在）と LP3（redirect）のテストは維持され、`pnpm test` で PASS する。
- [x] `pnpm test` が exit code 0 で終了する。
- [x] `pnpm lint` が exit code 0 で終了する。
- [x] `npx tsc --noEmit` が exit code 0 で終了する。

### ドキュメント

- [x] `docs/auth-architecture.md` 全体に対するテキスト検索で、Resend / Email Magic Link / `AUTH_RESEND_KEY` / `EMAIL_FROM` / `signIn('resend'` / `next-auth/providers/resend` のいずれもがアクティブな仕様記述として残っていない（廃止注記の文脈での言及は可）。
- [x] `docs/auth-test-plan.md` の Email Magic Link 関連テストケースと「実 Resend メール送信」関連の手動確認項目が、削除または「廃止」とマークされている。

## Trinity 実行サマリ

- Run: `.trinity/20260510T013129Z-remove-email-registration`
- Iterations: 1/15
- Final verdict: PASS
- Final commit: `0328b53`

## 判定根拠（最終 Evaluator レポートからの抜粋）

判定: PASS

検証チェーン（再実行）:
- typecheck: PASS — `npx tsc --noEmit` exit code 0
- lint: PASS — exit code 0、warning は既存ファイル 4 件のみ（エラー 0 件）
- unit: PASS — `pnpm exec vitest run` 473 passed / 0 failed、54 test files
- LP1, LP2(更新後), LP3 すべて PASS

機能性: handleEmailSignIn・email フォーム・Resend プロバイダ・環境変数が完全撤去され、Google サインインと `redirect('/')` は維持。スコープ外ファイル（schema.ts, middleware.ts 等）への変更なし。